### PR TITLE
chore: reduce use of legacy rules_go naming conventions

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,35 +1,30 @@
-load("@bazel_gazelle//:def.bzl", "gazelle", "gazelle_binary")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+load("@gazelle//:def.bzl", "gazelle", "gazelle_binary")
 
 # gazelle:lang go
 # gazelle:build_file_name BUILD.bazel
-
-# Only update and do not create new BUILDs
-# gazelle:generation_mode update_only
 
 # Go config
 # gazelle:go_naming_convention import
 # gazelle:go_naming_convention_external import
 
 # Use the gazelle bazel modules instead of go.mod modules
-# gazelle:resolve_regexp go github.com/bazelbuild/bazel-gazelle/(.*) @bazel_gazelle//$1:go_default_library
+# gazelle:resolve_regexp go github.com/bazelbuild/bazel-gazelle/(.*) @gazelle//$1
 # gazelle:resolve_regexp go github.com/bazel-contrib/rules_python/gazelle/(.*) @rules_python_gazelle_plugin//$1
-# gazelle:resolve_regexp go github.com/bazelbuild/rules_go/(.*) @io_bazel_rules_go//$1
+# gazelle:resolve_regexp go github.com/bazelbuild/rules_go/(.*) @rules_go//$1
 # gazelle:resolve_regexp go github.com/EngFlow/gazelle_cc/(.*) @gazelle_cc//$1
-
-# gazelle:resolve go github.com/bazelbuild/buildtools/build @com_github_bazelbuild_buildtools//build:go_default_library
 
 gazelle_binary(
     name = "gazelle_bin",
     languages = [
-        "@bazel_gazelle//language/go:go_default_library",
+        "@gazelle//language/go:go_default_library",
     ],
 )
 
 gazelle(
     name = "gazelle",
-    # extra_args = ["-index=lazy"],
+    extra_args = ["-index=lazy"],
     gazelle = ":gazelle_bin",
 )
 
@@ -37,7 +32,7 @@ bzl_library(
     name = "gazelle_lib",
     srcs = ["gazelle.bzl"],
     visibility = ["//visibility:public"],
-    deps = ["@bazel_gazelle//:def"],
+    deps = ["@gazelle//:def"],
 )
 
 alias(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,12 +5,8 @@ module(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.0.0")
 bazel_dep(name = "aspect_rules_js", version = "2.0.0")
-
-# rules_go
-bazel_dep(name = "rules_go", version = "0.56.1", repo_name = "io_bazel_rules_go")
-
-# Gazelle
-bazel_dep(name = "gazelle", version = "0.45.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_go", version = "0.56.1")
+bazel_dep(name = "gazelle", version = "0.45.0")
 
 # Override the gazelle version used locally to pre-release and apply orion patches
 archive_override(
@@ -40,11 +36,11 @@ archive_override(
 bazel_dep(name = "gazelle_cc", version = "0.1.0")
 
 # Go modules
-go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 use_repo(go_deps, "com_github_bazelbuild_bazel_gazelle", "com_github_bazelbuild_buildtools", "com_github_bmatcuk_doublestar_v4", "com_github_emirpasic_gods", "com_github_engflow_gazelle_cc", "com_github_fatih_color", "com_github_go_git_go_git_v5", "com_github_itchyny_gojq", "com_github_masterminds_semver_v3", "com_github_mikefarah_yq_v4", "com_github_msolo_jsonr", "com_github_onsi_gomega", "com_github_pmezard_go_difflib", "com_github_smacker_go_tree_sitter", "in_gopkg_op_go_logging_v1", "in_gopkg_yaml_v3", "io_opentelemetry_go_otel", "io_opentelemetry_go_otel_trace", "net_starlark_go", "org_golang_google_genproto_googleapis_api", "org_golang_x_sync", "org_golang_x_term", "org_golang_x_tools")
 
-go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.nogo(nogo = "//bazel/go:nogo")
 use_repo(go_sdk, "go_sdk")
 
@@ -153,14 +149,14 @@ visibility = ["//visibility:public"],
 ####### Dev dependencies ########
 
 # Locally only# Go SDK version which can only be defined in a root MODULE
-go_sdk2 = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
+go_sdk2 = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
 go_sdk2.from_file(
     name = "go_sdk",
     go_mod = "//:go.mod",
 )
 
 # Go modules
-go_deps2 = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps", dev_dependency = True)
+go_deps2 = use_extension("@gazelle//:extensions.bzl", "go_deps", dev_dependency = True)
 go_deps2.module_override(
     patch_strip = 1,
     patches = [

--- a/bazel/go/BUILD.bazel
+++ b/bazel/go/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "nogo")
+load("@rules_go//go:def.bzl", "go_library", "nogo")
 
 nogo(
     name = "nogo",

--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "common",
@@ -14,12 +14,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//common/logger",
-        "@bazel_gazelle//label:go_default_library",
-        "@bazel_gazelle//language:go_default_library",
-        "@bazel_gazelle//rule:go_default_library",
-        "@bazel_gazelle//walk:go_default_library",
         "@com_github_emirpasic_gods//sets/treeset",
         "@com_github_emirpasic_gods//utils",
         "@com_github_itchyny_gojq//:gojq",
+        "@gazelle//label",
+        "@gazelle//language",
+        "@gazelle//rule",
+        "@gazelle//walk",
     ],
 )

--- a/common/bazel/BUILD.bazel
+++ b/common/bazel/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "bazel",

--- a/common/bazel/workspace/BUILD.bazel
+++ b/common/bazel/workspace/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "workspace",

--- a/common/buildinfo/BUILD.bazel
+++ b/common/buildinfo/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 # Under --stamp, the Go linker will fill in these placeholders with VCS info
 # see https://github.com/bazelbuild/rules_go/blob/master/go/core.rst#stamping-with-the-workspace-status-script

--- a/common/cache/BUILD.bazel
+++ b/common/cache/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "cache",
@@ -15,8 +15,8 @@ go_library(
         "//common/buildinfo",
         "//common/logger",
         "//common/watch",
-        "@bazel_gazelle//config:go_default_library",
-        "@bazel_gazelle//language:go_default_library",
-        "@bazel_gazelle//rule:go_default_library",
+        "@gazelle//config",
+        "@gazelle//language",
+        "@gazelle//rule",
     ],
 )

--- a/common/ibp/BUILD.bazel
+++ b/common/ibp/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "ibp",

--- a/common/logger/BUILD.bazel
+++ b/common/logger/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "logger",

--- a/common/progress/BUILD.bazel
+++ b/common/progress/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "progress",
@@ -6,12 +6,12 @@ go_library(
     importpath = "github.com/aspect-build/aspect-gazelle/common/progress",
     visibility = ["//visibility:public"],
     deps = [
-        "@bazel_gazelle//config:go_default_library",
-        "@bazel_gazelle//label:go_default_library",
-        "@bazel_gazelle//language:go_default_library",
-        "@bazel_gazelle//repo:go_default_library",
-        "@bazel_gazelle//resolve:go_default_library",
-        "@bazel_gazelle//rule:go_default_library",
+        "@gazelle//config",
+        "@gazelle//label",
+        "@gazelle//language",
+        "@gazelle//repo",
+        "@gazelle//resolve",
+        "@gazelle//rule",
         "@org_golang_x_term//:term",
     ],
 )

--- a/common/socket/BUILD.bazel
+++ b/common/socket/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "socket",

--- a/common/starlark/BUILD.bazel
+++ b/common/starlark/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "starlark",
@@ -12,10 +12,10 @@ go_library(
     deps = [
         "//common/logger",
         "//common/starlark/stdlib",
-        "@bazel_gazelle//label:go_default_library",
-        "@bazel_gazelle//rule:go_default_library",
-        "@com_github_bazelbuild_buildtools//build:go_default_library",
+        "@com_github_bazelbuild_buildtools//build",
         "@com_github_bmatcuk_doublestar_v4//:doublestar",
+        "@gazelle//label",
+        "@gazelle//rule",
         "@net_starlark_go//lib/json",
         "@net_starlark_go//starlark",
         "@net_starlark_go//syntax",

--- a/common/starlark/stdlib/BUILD.bazel
+++ b/common/starlark/stdlib/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "stdlib",

--- a/common/starlark/utils/BUILD.bazel
+++ b/common/starlark/utils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "utils",

--- a/common/treesitter/BUILD.bazel
+++ b/common/treesitter/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "treesitter",

--- a/common/treesitter/grammars/golang/BUILD.bazel
+++ b/common/treesitter/grammars/golang/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "golang",

--- a/common/treesitter/grammars/java/BUILD.bazel
+++ b/common/treesitter/grammars/java/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "java",

--- a/common/treesitter/grammars/json/BUILD.bazel
+++ b/common/treesitter/grammars/json/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "json",

--- a/common/treesitter/grammars/kotlin/BUILD.bazel
+++ b/common/treesitter/grammars/kotlin/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "kotlin",

--- a/common/treesitter/grammars/rust/BUILD.bazel
+++ b/common/treesitter/grammars/rust/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "rust",

--- a/common/treesitter/grammars/starlark/BUILD.bazel
+++ b/common/treesitter/grammars/starlark/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "starlark",

--- a/common/treesitter/grammars/tsx/BUILD.bazel
+++ b/common/treesitter/grammars/tsx/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "tsx",

--- a/common/treesitter/grammars/typescript/BUILD.bazel
+++ b/common/treesitter/grammars/typescript/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "typescript",

--- a/common/watch/BUILD.bazel
+++ b/common/watch/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "watch",

--- a/gazelle.bzl
+++ b/gazelle.bzl
@@ -1,6 +1,6 @@
 """Utils for writing aspect-cli gazelle plugins"""
 
-load("@bazel_gazelle//:def.bzl", _gazelle_generation_test = "gazelle_generation_test")
+load("@gazelle//:def.bzl", _gazelle_generation_test = "gazelle_generation_test")
 
 def gazelle_generation_test(name, gazelle_binary, dir, data = [], **kwargs):
     """Creates a gazelle_generation_test target while supporting files such as ".gitignore" by prefixing with ".test-*"

--- a/language/js/BUILD.bazel
+++ b/language/js/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel_gazelle//:def.bzl", "gazelle_binary")
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@gazelle//:def.bzl", "gazelle_binary")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 load("//:gazelle.bzl", "gazelle_generation_test")
 
 # gazelle:exclude tests/
@@ -28,18 +28,18 @@ go_library(
         "//language/js/pnpm",
         "//language/js/proto",
         "//language/js/typescript",
-        "@bazel_gazelle//config:go_default_library",
-        "@bazel_gazelle//label:go_default_library",
-        "@bazel_gazelle//language:go_default_library",
-        "@bazel_gazelle//repo:go_default_library",
-        "@bazel_gazelle//resolve:go_default_library",
-        "@bazel_gazelle//rule:go_default_library",
-        "@com_github_bazelbuild_buildtools//build:go_default_library",
+        "@com_github_bazelbuild_buildtools//build",
         "@com_github_bmatcuk_doublestar_v4//:doublestar",
         "@com_github_emirpasic_gods//maps/linkedhashmap",
         "@com_github_emirpasic_gods//maps/treemap",
         "@com_github_emirpasic_gods//sets/treeset",
         "@com_github_emirpasic_gods//utils",
+        "@gazelle//config",
+        "@gazelle//label",
+        "@gazelle//language",
+        "@gazelle//repo",
+        "@gazelle//resolve",
+        "@gazelle//rule",
     ],
 )
 
@@ -55,7 +55,7 @@ gazelle_binary(
     name = "gazelle_js_binary",
     testonly = True,
     languages = [
-        "@bazel_gazelle//language/proto:go_default_library",
+        "@gazelle//language/proto:go_default_library",
         ":js",
     ],
     visibility = ["//visibility:private"],

--- a/language/js/node/BUILD.bazel
+++ b/language/js/node/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_file")
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "node",

--- a/language/js/parser/BUILD.bazel
+++ b/language/js/parser/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "parser",

--- a/language/js/pnpm/BUILD.bazel
+++ b/language/js/pnpm/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "pnpm",
@@ -12,8 +12,8 @@ go_library(
     importpath = "github.com/aspect-build/aspect-gazelle/language/js/pnpm",
     visibility = ["//visibility:public"],
     deps = [
-        "@bazel_gazelle//label:go_default_library",
         "@com_github_masterminds_semver_v3//:semver",
+        "@gazelle//label",
         "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )

--- a/language/js/proto/BUILD.bazel
+++ b/language/js/proto/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "proto",
@@ -6,8 +6,8 @@ go_library(
     importpath = "github.com/aspect-build/aspect-gazelle/language/js/proto",
     visibility = ["//visibility:public"],
     deps = [
-        "@bazel_gazelle//language:go_default_library",
-        "@bazel_gazelle//language/proto:go_default_library",
-        "@bazel_gazelle//rule:go_default_library",
+        "@gazelle//language",
+        "@gazelle//language/proto",
+        "@gazelle//rule",
     ],
 )

--- a/language/js/typescript/BUILD.bazel
+++ b/language/js/typescript/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "typescript",

--- a/language/orion/BUILD.bazel
+++ b/language/orion/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel_gazelle//:def.bzl", "gazelle_binary")
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@gazelle//:def.bzl", "gazelle_binary")
+load("@rules_go//go:def.bzl", "go_library")
 
 # gazelle:exclude tests/
 
@@ -23,15 +23,15 @@ go_library(
         "//language/orion/plugin",
         "//language/orion/queries",
         "//language/orion/starzelle",
-        "@bazel_gazelle//config:go_default_library",
-        "@bazel_gazelle//label:go_default_library",
-        "@bazel_gazelle//language:go_default_library",
-        "@bazel_gazelle//repo:go_default_library",
-        "@bazel_gazelle//resolve:go_default_library",
-        "@bazel_gazelle//rule:go_default_library",
         "@com_github_bmatcuk_doublestar_v4//:doublestar",
         "@com_github_emirpasic_gods//maps/linkedhashmap",
         "@com_github_emirpasic_gods//sets/treeset",
+        "@gazelle//config",
+        "@gazelle//label",
+        "@gazelle//language",
+        "@gazelle//repo",
+        "@gazelle//resolve",
+        "@gazelle//rule",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/language/orion/plugin/BUILD.bazel
+++ b/language/orion/plugin/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "plugin",

--- a/language/orion/queries/BUILD.bazel
+++ b/language/orion/queries/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "queries",

--- a/language/orion/starzelle/BUILD.bazel
+++ b/language/orion/starzelle/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "starzelle",

--- a/runner/BUILD.bazel
+++ b/runner/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "runner",
@@ -14,10 +14,10 @@ go_library(
         "//runner/language/bzl",
         "//runner/language/python",
         "//runner/vendored/gazelle",
-        "@bazel_gazelle//config:go_default_library",
-        "@bazel_gazelle//language:go_default_library",
-        "@bazel_gazelle//language/go:go_default_library",
-        "@bazel_gazelle//language/proto:go_default_library",
+        "@gazelle//config",
+        "@gazelle//language",
+        "@gazelle//language/go",
+        "@gazelle//language/proto",
         "@gazelle_cc//language/cc",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel//attribute",
@@ -36,7 +36,7 @@ go_library(
         "//common/buildinfo",
         "//common/ibp",
         "//language/orion",
-        "@bazel_gazelle//language:go_default_library",
+        "@gazelle//language:go_default_library",
         "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )

--- a/runner/git/BUILD.bazel
+++ b/runner/git/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 # Export patch so other repositories can depend on it.
 exports_files(["gazelle-gitignore.patch"])
@@ -10,8 +10,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//common/logger",
-        "@bazel_gazelle//walk:go_default_library",
         "@com_github_go_git_go_git_v5//plumbing/format/gitignore",
+        "@gazelle//walk",
     ],
 )
 

--- a/runner/git/testing/BUILD.bazel
+++ b/runner/git/testing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "testing",
@@ -8,11 +8,11 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//runner/git",
-        "@bazel_gazelle//config:go_default_library",
-        "@bazel_gazelle//label:go_default_library",
-        "@bazel_gazelle//language:go_default_library",
-        "@bazel_gazelle//repo:go_default_library",
-        "@bazel_gazelle//resolve:go_default_library",
-        "@bazel_gazelle//rule:go_default_library",
+        "@gazelle//config",
+        "@gazelle//label",
+        "@gazelle//language",
+        "@gazelle//repo",
+        "@gazelle//resolve",
+        "@gazelle//rule",
     ],
 )

--- a/runner/git/tests/BUILD.bazel
+++ b/runner/git/tests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_gazelle//:def.bzl", "gazelle_binary")
+load("@gazelle//:def.bzl", "gazelle_binary")
 load("//:gazelle.bzl", "gazelle_generation_test")
 
 # Disable the gazelle extensions

--- a/runner/language/bzl/BUILD.bazel
+++ b/runner/language/bzl/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@bazel_gazelle//:def.bzl", "gazelle_binary")
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@gazelle//:def.bzl", "gazelle_binary")
+load("@rules_go//go:def.bzl", "go_library")
 load("//:gazelle.bzl", "gazelle_generation_test")
 
 # gazelle:exclude tests/
@@ -9,14 +9,14 @@ go_library(
     importpath = "github.com/aspect-build/aspect-gazelle/runner/language/bzl",
     visibility = ["//visibility:public"],
     deps = [
-        "@bazel_gazelle//config:go_default_library",
-        "@bazel_gazelle//label:go_default_library",
-        "@bazel_gazelle//language:go_default_library",
-        "@bazel_gazelle//pathtools:go_default_library",
-        "@bazel_gazelle//repo:go_default_library",
-        "@bazel_gazelle//resolve:go_default_library",
-        "@bazel_gazelle//rule:go_default_library",
-        "@com_github_bazelbuild_buildtools//build:go_default_library",
+        "@com_github_bazelbuild_buildtools//build",
+        "@gazelle//config",
+        "@gazelle//label",
+        "@gazelle//language",
+        "@gazelle//pathtools",
+        "@gazelle//repo",
+        "@gazelle//resolve",
+        "@gazelle//rule",
     ],
 )
 
@@ -25,7 +25,7 @@ gazelle_binary(
     name = "gazelle_bzl_binary",
     testonly = True,
     languages = [
-        "@bazel_gazelle//language/proto:go_default_library",
+        "@gazelle//language/proto:go_default_library",
         ":bzl",
     ],
     visibility = ["//visibility:private"],

--- a/runner/language/python/BUILD.bazel
+++ b/runner/language/python/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "python",
@@ -9,24 +9,24 @@ go_library(
     importpath = "github.com/aspect-build/aspect-gazelle/runner/language/python",
     visibility = ["//visibility:public"],
     deps = select({
-        "@io_bazel_rules_go//go/platform:android": [
-            "@bazel_gazelle//language:go_default_library",
+        "@rules_go//go/platform:android": [
+            "@gazelle//language",
             "@rules_python_gazelle_plugin//python",
         ],
-        "@io_bazel_rules_go//go/platform:darwin": [
-            "@bazel_gazelle//language:go_default_library",
+        "@rules_go//go/platform:darwin": [
+            "@gazelle//language",
             "@rules_python_gazelle_plugin//python",
         ],
-        "@io_bazel_rules_go//go/platform:ios": [
-            "@bazel_gazelle//language:go_default_library",
+        "@rules_go//go/platform:ios": [
+            "@gazelle//language",
             "@rules_python_gazelle_plugin//python",
         ],
-        "@io_bazel_rules_go//go/platform:linux": [
-            "@bazel_gazelle//language:go_default_library",
+        "@rules_go//go/platform:linux": [
+            "@gazelle//language",
             "@rules_python_gazelle_plugin//python",
         ],
-        "@io_bazel_rules_go//go/platform:windows": [
-            "@bazel_gazelle//language:go_default_library",
+        "@rules_go//go/platform:windows": [
+            "@gazelle//language",
         ],
         "//conditions:default": [],
     }),

--- a/runner/tests/BUILD.bazel
+++ b/runner/tests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_gazelle//:def.bzl", "gazelle_binary")
+load("@gazelle//:def.bzl", "gazelle_binary")
 load("//:gazelle.bzl", "gazelle_generation_test")
 
 # Disable the gazelle extensions

--- a/runner/vendored/gazelle/BUILD.bazel
+++ b/runner/vendored/gazelle/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "gazelle",
@@ -16,16 +16,16 @@ go_library(
     deps = [
         "//common/cache",
         "//runner/vendored/gazelle/internal/wspace",
-        "@bazel_gazelle//config:go_default_library",
-        "@bazel_gazelle//flag:go_default_library",
-        "@bazel_gazelle//label:go_default_library",
-        "@bazel_gazelle//language:go_default_library",
-        "@bazel_gazelle//merger:go_default_library",
-        "@bazel_gazelle//repo:go_default_library",
-        "@bazel_gazelle//resolve:go_default_library",
-        "@bazel_gazelle//rule:go_default_library",
-        "@bazel_gazelle//walk:go_default_library",
-        "@com_github_bazelbuild_buildtools//build:go_default_library",
+        "@com_github_bazelbuild_buildtools//build",
         "@com_github_pmezard_go_difflib//difflib",
+        "@gazelle//config",
+        "@gazelle//flag",
+        "@gazelle//label",
+        "@gazelle//language",
+        "@gazelle//merger",
+        "@gazelle//repo",
+        "@gazelle//resolve",
+        "@gazelle//rule",
+        "@gazelle//walk",
     ],
 )

--- a/runner/vendored/gazelle/internal/wspace/BUILD.bazel
+++ b/runner/vendored/gazelle/internal/wspace/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "wspace",

--- a/tests/e2e/BUILD.bazel
+++ b/tests/e2e/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_gazelle//:def.bzl", "gazelle_binary")
+load("@gazelle//:def.bzl", "gazelle_binary")
 load("//:gazelle.bzl", "gazelle_generation_test")
 
 # Disable the gazelle extensions


### PR DESCRIPTION
This is legacy from when moving rules_go from WORKSPACE to MODULE. Lets start fresh the modern way of doing things in this repo.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
