### PR TITLE
test: use aspect gazelle runner for e2e tests

### DIFF
--- a/runner/BUILD.bazel
+++ b/runner/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//common/ibp",
         "//common/progress",
         "//language/js",
+        "//language/orion",
         "//runner/git",
         "//runner/language/bzl",
         "//runner/language/python",

--- a/runner/tests/BUILD.bazel
+++ b/runner/tests/BUILD.bazel
@@ -1,19 +1,8 @@
-load("@gazelle//:def.bzl", "gazelle_binary")
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
 load("//:gazelle.bzl", "gazelle_generation_test")
 
 # Disable the gazelle extensions
-# gazelle:exclude .
-
-gazelle_binary(
-    name = "gazelle_bin",
-    testonly = True,
-    languages = [
-        "//language/js",
-        "//language/orion",
-        "//runner/git/testing",
-    ],
-    visibility = ["//visibility:private"],
-)
+# gazelle:exclude tests/**
 
 [
     gazelle_generation_test(
@@ -25,7 +14,21 @@ gazelle_binary(
                 t,
             ),
         },
-        gazelle_binary = ":gazelle_bin",
+        gazelle_binary = ":tests",
     )
     for t in [t.replace("/WORKSPACE", "") for t in glob(["*/WORKSPACE"])]
 ]
+
+go_library(
+    name = "tests_lib",
+    srcs = ["test.go"],
+    importpath = "github.com/aspect-build/aspect-gazelle/runner/tests",
+    visibility = ["//visibility:private"],
+    deps = ["//runner"],
+)
+
+go_binary(
+    name = "tests",
+    embed = [":tests_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/runner/tests/npm_bin_wrapper/BUILD.in
+++ b/runner/tests/npm_bin_wrapper/BUILD.in
@@ -1,1 +1,2 @@
+# gazelle:lang js,orion
 # gazelle:js_files postcss_config postcss.config.mjs

--- a/runner/tests/npm_bin_wrapper/BUILD.out
+++ b/runner/tests/npm_bin_wrapper/BUILD.out
@@ -1,5 +1,6 @@
 load("@npm//:defs.bzl", "npm_link_all_packages")
 
+# gazelle:lang js,orion
 # gazelle:js_files postcss_config postcss.config.mjs
 
 npm_link_all_packages(name = "node_modules")

--- a/runner/tests/test.go
+++ b/runner/tests/test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/aspect-build/aspect-gazelle/runner"
+)
+
+func main() {
+	log.SetPrefix("gazelle: ")
+	log.SetFlags(0) // don't print timestamps
+
+	if wd := os.Getenv("BUILD_WORKSPACE_DIRECTORY"); wd != "" {
+		_ = os.Chdir(wd)
+	}
+
+	c := runner.New()
+
+	c.AddLanguage(runner.JavaScript)
+	c.AddLanguage(runner.Orion)
+	c.AddLanguage(runner.Bzl)
+	c.AddLanguage(runner.Go)
+	c.AddLanguage(runner.Protobuf)
+	c.AddLanguage(runner.Python)
+	c.AddLanguage(runner.CC)
+
+	_, err := c.Test()
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Add a "aspect-gazelle" test runner, which is essentially just the aspect-cli `configure` with 100% of the plugins enabled. Today this is only used for what has been categorized as "e2e" tests.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
