### PR TITLE
chore: add missing tree-sitter-rust http_archive(sha256)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -99,6 +99,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 """,
+    sha256 = "faad55f71adcdc6a1b4c0266971ea4998d2d039d23161dfdb03a6fa558ce1a7b",
     urls = ["https://github.com/tree-sitter/tree-sitter-rust/releases/download/v0.24.0/tree-sitter-rust.tar.gz"],
 )
 


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
