### PR TITLE
refactor: add gazelle resolve_regex suggestion to error message

### DIFF
--- a/language/js/resolve.go
+++ b/language/js/resolve.go
@@ -419,12 +419,14 @@ func (ts *typeScriptLang) resolveImports(
 				notFound := fmt.Errorf(
 					"Import %[1]q from %[2]q is an unknown dependency. Possible solutions:\n"+
 						"\t1. Instruct Gazelle to resolve to a known dependency using a directive:\n"+
-						"\t\t# aspect:resolve [src-lang] js import-string label\n"+
+						"\t\t# aspect:resolve [src-lang] %[5]s import-string label\n"+
+						"\t\t   or\n"+
+						"\t\t# aspect:resolve_regex [src-lang] %[5]s import-string-regex label\n"+
 						"\t\t   or\n"+
 						"\t\t# aspect:js_resolve import-string-glob label\n"+
 						"\t2. Ignore the dependency using the '# aspect:%[3]s %[1]s' directive.\n"+
 						"\t3. Disable Gazelle resolution validation using '# aspect:%[4]s off'",
-					imp.ImportPath, imp.SourcePath, Directive_IgnoreImports, Directive_ValidateImportStatements,
+					imp.ImportPath, imp.SourcePath, Directive_IgnoreImports, Directive_ValidateImportStatements, LanguageName,
 				)
 				resolutionErrors = append(resolutionErrors, notFound)
 			}

--- a/language/js/tests/validate_import_statements/expectedStderr.txt
+++ b/language/js/tests/validate_import_statements/expectedStderr.txt
@@ -4,6 +4,8 @@ Import "bad-import" from "main.ts" is an unknown dependency. Possible solutions:
 	1. Instruct Gazelle to resolve to a known dependency using a directive:
 		# aspect:resolve [src-lang] js import-string label
 		   or
+		# aspect:resolve_regex [src-lang] js import-string-regex label
+		   or
 		# aspect:js_resolve import-string-glob label
 	2. Ignore the dependency using the '# aspect:js_ignore_imports bad-import' directive.
 	3. Disable Gazelle resolution validation using '# aspect:js_validate_import_statements off'
@@ -11,6 +13,8 @@ Import "bad-import" from "main.ts" is an unknown dependency. Possible solutions:
 Import "bad-import2" from "main.ts" is an unknown dependency. Possible solutions:
 	1. Instruct Gazelle to resolve to a known dependency using a directive:
 		# aspect:resolve [src-lang] js import-string label
+		   or
+		# aspect:resolve_regex [src-lang] js import-string-regex label
 		   or
 		# aspect:js_resolve import-string-glob label
 	2. Ignore the dependency using the '# aspect:js_ignore_imports bad-import2' directive.

--- a/language/js/tests/validate_import_statements_warn/expectedStderr.txt
+++ b/language/js/tests/validate_import_statements_warn/expectedStderr.txt
@@ -4,6 +4,8 @@ Import "bad-import" from "main.ts" is an unknown dependency. Possible solutions:
 	1. Instruct Gazelle to resolve to a known dependency using a directive:
 		# aspect:resolve [src-lang] js import-string label
 		   or
+		# aspect:resolve_regex [src-lang] js import-string-regex label
+		   or
 		# aspect:js_resolve import-string-glob label
 	2. Ignore the dependency using the '# aspect:js_ignore_imports bad-import' directive.
 	3. Disable Gazelle resolution validation using '# aspect:js_validate_import_statements off'


### PR DESCRIPTION
The original reason for `js_resolve` was the lack of regex/glob support which gazelle has now supported for a while, lets make sure `resolve_regex` is suggested while keeping `js_resolve` for now.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
