### PR TITLE
refactor: upgrade tree-sitter go grammar to 0.25.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,8 +23,8 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 """,
-    integrity = "sha256-M7w7RN4de4FfUv6fQuSXhsWDPZGB/Vn9aRDBnIJVkik=",
-    urls = ["https://github.com/tree-sitter/tree-sitter-go/releases/download/v0.23.4/tree-sitter-go.tar.xz"],
+    sha256 = "ac412018d59f7cd5bb72fbde557e9ebf9fdfac12c5853f2bb03669f980a953bb",
+    urls = ["https://github.com/tree-sitter/tree-sitter-go/releases/download/v0.25.0/tree-sitter-go.tar.gz"],
 )
 
 http_archive(


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
