### PR TITLE
fix: watchman caching of symlink reads

### DIFF
--- a/runner/pkg/watchman/BUILD.bazel
+++ b/runner/pkg/watchman/BUILD.bazel
@@ -20,7 +20,10 @@ go_library(
 
 go_test(
     name = "watchman_test",
-    srcs = ["watch_test.go"],
+    srcs = [
+        "cache_test.go",
+        "watch_test.go",
+    ],
     embed = [":watchman"],
     tags = ["manual"],  # TODO: we need watchman in our runners.
 )

--- a/runner/pkg/watchman/cache_test.go
+++ b/runner/pkg/watchman/cache_test.go
@@ -1,0 +1,98 @@
+package watchman
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoadOrStoreFile(t *testing.T) {
+	tmp := getTempDir(t)
+	defer os.RemoveAll(tmp)
+
+	if err := os.WriteFile(tmp+"/test", []byte("test"), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %s", err)
+	}
+
+	w := createWatchman(tmp)
+
+	err := w.Start()
+	if err != nil {
+		t.Errorf("Expected to start watching: %s", err)
+	}
+	defer w.Stop()
+	defer w.Close()
+
+	c := newWatchmanCache(w, getTempFile(t))
+
+	computes := 0
+	compute := func(path string, content []byte) (any, error) {
+		computes++
+		return string(content), nil
+	}
+
+	res, cached, err := c.LoadOrStoreFile(tmp, "test", "op1", compute)
+	if err != nil {
+		t.Errorf("Expected to load or store file: %s", err)
+	}
+	if cached {
+		t.Errorf("Expected not cached on first load")
+	}
+	if res.(string) != "test" {
+		t.Errorf("Expected content 'test', got '%s'", res.(string))
+	}
+
+	res2, cached2, err2 := c.LoadOrStoreFile(tmp, "test", "op1", compute)
+	if err2 != nil {
+		t.Errorf("Expected to load or store file: %s", err2)
+	}
+	if !cached2 {
+		t.Errorf("Expected cached on second load")
+	}
+	if res2.(string) != res {
+		t.Errorf("Expected content '%s', got '%s'", res, res2)
+	}
+
+	if computes != 1 {
+		t.Errorf("Expected 1 compute, got %d", computes)
+	}
+}
+
+func TestLoadOrStoreFileSymlink(t *testing.T) {
+	tmp := getTempDir(t)
+	defer os.RemoveAll(tmp)
+
+	os.WriteFile(tmp+"/test", []byte("test"), 0644)
+	os.Symlink("test", tmp+"/test-symlink")
+
+	w := createWatchman(tmp)
+
+	err := w.Start()
+	if err != nil {
+		t.Errorf("Expected to start watching: %s", err)
+	}
+	defer w.Stop()
+	defer w.Close()
+
+	c := newWatchmanCache(w, getTempFile(t))
+
+	computes := 0
+	compute := func(path string, content []byte) (any, error) {
+		computes++
+		return string(content), nil
+	}
+
+	res, _, _ := c.LoadOrStoreFile(tmp, "test", "op1", compute)
+	res2, _, err := c.LoadOrStoreFile(tmp, "test-symlink", "op1", compute)
+
+	if err != nil {
+		t.Errorf("Expected to load or store file: %s", err)
+	}
+
+	if res2 != res {
+		t.Errorf("Expected content '%s', got '%s'", res, res2)
+	}
+
+	if computes != 1 {
+		t.Errorf("Expected 1 compute, got %d", computes)
+	}
+}

--- a/runner/pkg/watchman/watch.go
+++ b/runner/pkg/watchman/watch.go
@@ -143,7 +143,7 @@ func (w *WatchmanWatcher) getWatchmanSocket() (string, error) {
 	cmd := exec.Command(w.watchmanPath, "get-sockname")
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to get watchman socket: %w", err)
+		return "", fmt.Errorf("watchman get-sockname failed: %w", err)
 	}
 
 	var sockname map[string]string

--- a/runner/pkg/watchman/watch_test.go
+++ b/runner/pkg/watchman/watch_test.go
@@ -15,12 +15,21 @@ func getTempDir(t *testing.T) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Log(tmp)
 	tmp, err = os.MkdirTemp(tmp, "watchman-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Log(tmp)
 	return tmp
+}
+
+func getTempFile(t *testing.T) string {
+	f, err := os.CreateTemp(os.TempDir(), "test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(f.Name())
+	return f.Name()
 }
 
 func createWatchman(root string) *WatchmanWatcher {


### PR DESCRIPTION
When using watchman cache invalidation is based on the real filepath, so cache persisting must also use the real path and not a symlink path.

Fix https://github.com/aspect-build/aspect-gazelle/issues/85

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce:
