### PR TITLE
refactor: add aspect-gazelle binary

### DIFF
--- a/runner/BUILD.bazel
+++ b/runner/BUILD.bazel
@@ -1,5 +1,7 @@
-load("@gazelle//:def.bzl", "gazelle", "gazelle_binary")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@gazelle//:def.bzl", "gazelle")
 load("@rules_go//go:def.bzl", "go_library")
+load("//:def.bzl", "aspect_gazelle")
 
 # Use the gazelle bazel modules instead of go.mod modules
 # gazelle:resolve_regexp go github.com/bazelbuild/bazel-gazelle/(.*) @gazelle//$1
@@ -11,6 +13,7 @@ load("@rules_go//go:def.bzl", "go_library")
 # gazelle:resolve_regexp go github.com/aspect-build/aspect-gazelle/language/kotlin @aspect_gazelle_kotlin
 # gazelle:resolve_regexp go github.com/aspect-build/aspect-gazelle/runner/(.*) //$1
 
+# Pure gazelle targets
 gazelle(
     name = "gazelle",
     extra_args = ["-index=lazy"],
@@ -23,20 +26,23 @@ gazelle(
     mode = "diff",
 )
 
-gazelle_binary(
+# Aspect gazelle targets - should be functionally identical to above but with added aspect functionality
+aspect_gazelle(
+    name = "aspect_gazelle",
+    extra_args = ["-index=lazy"],
+    languages = ["go"],
+)
+
+aspect_gazelle(
+    name = "aspect_gazelle.check",
+    languages = ["go"],
+    mode = "diff",
+)
+
+# The target used to publish the prebuilt gazelle binary.
+alias(
     name = "gazelle_prebuilt_bin",
-    languages = [
-        "//language/bzl",
-        "@rules_python_gazelle_plugin//python",
-        "@aspect_gazelle_js",
-        # Kotlin not included in the prebuild because it interferes with normal operation
-        # and there is no directive to disable it.
-        # "@aspect_gazelle_kotlin",
-        "@aspect_gazelle_orion",
-        "@gazelle_cc//language/cc",
-        "@gazelle//language/proto",
-        "@gazelle//language/go",
-    ],
+    actual = "//bin/gazelle:gazelle",
     visibility = ["//visibility:public"],
 )
 
@@ -73,4 +79,11 @@ go_library(
         "@org_golang_x_term//:term",
         "@rules_python_gazelle_plugin//python",
     ],
+)
+
+bzl_library(
+    name = "def",
+    srcs = ["def.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@gazelle//:def"],
 )

--- a/runner/bin/cli/BUILD.bazel
+++ b/runner/bin/cli/BUILD.bazel
@@ -18,5 +18,6 @@ go_library(
 go_binary(
     name = "cli",
     embed = [":cli_lib"],
+    tags = ["supports_incremental_build_protocol"],
     visibility = ["//visibility:public"],
 )

--- a/runner/bin/cli/main.go
+++ b/runner/bin/cli/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	mode, languages, plugins, args := parseArgs()
 
-	c := runner.New()
+	c := runner.New(os.Getenv("GAZELLE_PROGRESS") != "")
 
 	// Add languages
 	fmt.Printf("Languages: %v\n", languages)
@@ -47,14 +47,14 @@ func main() {
 	fmt.Printf("Args: %v\n", args)
 
 	if watchSocket := os.Getenv(ibp.PROTOCOL_SOCKET_ENV); watchSocket != "" {
-		err := c.Watch(watchSocket, mode, args)
+		err := c.Watch(watchSocket, runner.UpdateCmd, mode, args)
 
 		// Handle command errors
 		if err != nil {
 			log.Fatalf("Error running gazelle watcher: %v", err)
 		}
 	} else {
-		_, err := c.Generate(mode, args)
+		_, err := c.Generate(runner.UpdateCmd, mode, args)
 
 		// Handle command errors
 		if err != nil {

--- a/runner/bin/gazelle/BUILD.bazel
+++ b/runner/bin/gazelle/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "gazelle_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/aspect-build/aspect-gazelle/runner/bin/gazelle",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:runner",
+        "//pkg/ibp",
+        "@aspect_gazelle//common/logger",
+    ],
+)
+
+go_binary(
+    name = "gazelle",
+    embed = [":gazelle_lib"],
+    tags = ["supports_incremental_build_protocol"],
+    visibility = ["//visibility:public"],
+)

--- a/runner/bin/gazelle/main.go
+++ b/runner/bin/gazelle/main.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"log"
+	"os"
+	"slices"
+	"strings"
+
+	BazelLog "github.com/aspect-build/aspect-gazelle/common/logger"
+	"github.com/aspect-build/aspect-gazelle/runner"
+	"github.com/aspect-build/aspect-gazelle/runner/pkg/ibp"
+)
+
+var envLanguages = []runner.GazelleLanguage{
+	// Kotlin not included in the prebuild because it interferes with normal operation
+	// and there is no directive to disable it.
+	// runner.Kotlin,
+	runner.Go,
+	runner.Protobuf,
+	runner.Bzl,
+	runner.Python,
+	runner.Orion,
+	runner.CC,
+	runner.JavaScript,
+}
+
+func init() {
+	if langs := os.Getenv("ENABLE_LANGUAGES"); langs != "" {
+		envLanguages = strings.Split(langs, ",")
+
+		BazelLog.Infof("Using ENABLE_LANGUAGES from environment: %v", envLanguages)
+
+		// Automatically include orion if extensions are specified
+		if (os.Getenv("ORION_EXTENSIONS") != "" || os.Getenv("ORION_EXTENSIONS_DIR") != "") && !slices.Contains(envLanguages, runner.Orion) {
+			envLanguages = append(envLanguages, runner.Orion)
+		}
+	}
+}
+
+/**
+ * A `gazelle_binary` replacement where languages can be toggled at runtime.
+ *
+ * Supports additional features such as incremental builds via the Incremental Build Protocol,
+ * interactive terminal progress, tracing and more.
+ */
+func main() {
+	// Convenience for local development: under `bazel run <binary target>` respect the
+	// users working directory, don't run in the execroot
+	if wd, exists := os.LookupEnv("BUILD_WORKING_DIRECTORY"); exists {
+		_ = os.Chdir(wd)
+	}
+
+	cmd, mode, progress, args := parseArgs()
+
+	c := runner.New(progress)
+
+	// Add languages
+	for _, lang := range envLanguages {
+		c.AddLanguage(lang)
+	}
+
+	if watchSocket := os.Getenv(ibp.PROTOCOL_SOCKET_ENV); watchSocket != "" {
+		err := c.Watch(watchSocket, cmd, mode, args)
+		if err != nil {
+			log.Fatalf("Error running gazelle watcher: %v", err)
+		}
+	} else {
+		_, err := c.Generate(cmd, mode, args)
+		if err != nil {
+			log.Fatalf("Error running gazelle: %v", err)
+		}
+	}
+}
+
+/**
+ * Parse and extract arguments not directly passed along to gazelle.
+ */
+func parseArgs() (runner.GazelleCommand, runner.GazelleMode, bool, []string) {
+	args := os.Args[1:]
+
+	// The optional initial command argument
+	cmd := runner.UpdateCmd
+	if len(args) > 0 && (args[0] == runner.UpdateCmd || args[0] == runner.FixCmd) {
+		cmd = args[0]
+		args = args[1:]
+	}
+
+	// The optional --mode flag
+	mode, args := extractArg("--mode", runner.Fix, args)
+
+	// The optional --progress flag
+	progress, args := extractFlag("--progress", false, args)
+
+	return cmd, mode, progress, args
+}
+
+func extractFlag(flag string, defaultValue bool, args []string) (bool, []string) {
+	if i := slices.Index(args, flag); i != -1 {
+		args = append(args[:i], args[i+1:]...)
+		return true, args
+	}
+
+	return defaultValue, args
+}
+
+func extractArg(flag string, defaultValue string, args []string) (string, []string) {
+	i := slices.IndexFunc(args, func(s string) bool {
+		return s == flag || strings.HasPrefix(s, flag+"=")
+	})
+
+	if i == -1 {
+		return defaultValue, args
+	}
+
+	if args[i] == flag {
+		if len(args) == i {
+			log.Fatalf("ERROR: %s flag requires an argument", flag)
+			return defaultValue, args
+		}
+		value := args[i+1]
+		args = append(args[:i], args[i+2:]...)
+		return value, args
+	}
+
+	value := strings.SplitN(args[i], "=", 2)[1]
+	args = append(args[:i], args[i+1:]...)
+	return value, args
+}

--- a/runner/def.bzl
+++ b/runner/def.bzl
@@ -1,0 +1,70 @@
+"""
+Aspect enhanced Gazelle
+"""
+
+load("@gazelle//:def.bzl", "gazelle")
+
+def aspect_gazelle(languages = [], extensions = [], **kwargs):
+    """Creates a Gazelle target for BUILD file generation and update.
+
+    This macro provides an enhanced version of the standard `gazelle()` macro that:
+    - Bundles multiple well-supported language extensions into a single binary
+    - Supports Aspect Orion extensions for BUILD file generation via starlark extensions
+
+    Standard well-supported languages are built into the binary and enabled by default.
+    These include common languages like Go, Protobuf, and others. Use the `languages`
+    argument to enable only a specific subset if desired.
+
+    Aspect Orion extensions are Starlark-based plugins that provide additional BUILD
+    file generation capabilities beyond the standard language extensions. These can be
+    added via the `extensions` argument.
+
+    Example:
+        ```starlark
+        load("@aspect_gazelle_runner//:def.bzl", "aspect_gazelle")
+
+        # Basic usage with all default languages
+        aspect_gazelle(
+            name = "gazelle",
+        )
+
+        # Enable only specific languages
+        aspect_gazelle(
+            name = "gazelle_go_proto",
+            languages = ["go", "proto"],
+        )
+
+        # Add Orion extensions for custom generation
+        aspect_gazelle(
+            name = "gazelle_with_orion",
+            extensions = ["//tools/gazelle:my_extension.axl"],
+        )
+
+        # Update all BUILD files
+        aspect_gazelle(
+            name = "gazelle_update",
+            command = "fix",
+        )
+        ```
+
+    Args:
+        languages: A list of Gazelle language string keys to enable. If empty (default),
+            all built-in languages are enabled. Examples: ["go", "proto", "python"].
+        extensions: A list of labels pointing to Aspect Gazelle Orion Starlark extensions
+            to load. These extensions provide additional BUILD file generation logic.
+        **kwargs: Additional arguments passed directly to the underlying `gazelle()` macro including:
+            - `command`: The Gazelle command to run (e.g., "update", "fix")
+            - `mode`: The Gazelle mode (e.g., "diff", "update", "fix")
+            - `args`: Additional command-line arguments for Gazelle
+    """
+
+    gazelle(
+        gazelle = Label("@aspect_gazelle_runner//bin/gazelle:gazelle"),
+        env = kwargs.pop("env", {}) | {
+            "ENABLE_LANGUAGES": ",".join(languages),
+            "ORION_EXTENSIONS": ",".join(["$(rootpath %s)" % p for p in extensions]),
+        },
+        data = kwargs.pop("data", []) + extensions,
+        tags = kwargs.pop("tags", []) + ["supports_incremental_build_protocol"],
+        **kwargs
+    )

--- a/runner/tests/BUILD.bazel
+++ b/runner/tests/BUILD.bazel
@@ -8,6 +8,7 @@ load("@aspect_gazelle//:gazelle.bzl", "gazelle_generation_test")
         name = "%s_test" % t,
         dir = t,
         env = {
+            "ENABLE_LANGUAGES": "js,starlark,go,proto,python,cc",
             "ORION_EXTENSIONS_DIR": "%s/%s" % (
                 package_name(),
                 t,


### PR DESCRIPTION
`@aspect_gazelle_runner//bin/gazelle` is a binary designed to be equivalent to a `gazelle_binary()` with additional aspect enhancements:
* a specific set of languages tested and verified by Aspect
* ability to disable those languages
* ability to add starlark extensions
* `--progress` for terminal progress
* support for being run with the aspect cli `--watch`
* opt-in to additional caching

The `@aspect_gazelle_runner//:def.bzl` provides a replacement for `gazelle()` which uses the aspect binary and adds configuration of the languages and starlark extensions as rule attributes.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Provide an enhanced aspect-gazelle binary and `aspect_gazelle()` macro as drop-in replacements for gazelle.

### Test plan

- Covered by existing test cases
- Manual testing; use the `aspect_gazelle()` target in place of `gazelle()`
