### PR TITLE
refactor: support loading orion plugins via ORION_EXTENSIONS_DIR or ORION_EXTENSIONS

### DIFF
--- a/language/orion/README.md
+++ b/language/orion/README.md
@@ -8,9 +8,9 @@ See [Public Docsite](https://docs.aspect.build/cli/starlark/) for the plugin Sta
 
 ### Plugins via env
 
-Additional plugins will be loaded from `${ORION_EXTENSIONS}/*.axl` glob.
+Additional plugins will be loaded from `${ORION_EXTENSIONS_DIR}/*.axl` glob or from `${ORION_EXTENSIONS}` comma-separated list of paths.
 
-**FOR TESTING ONLY**: by default `ORION_EXTENSIONS=${RUNFILES_DIR}/aspect_silo/plugins/*.axl` for unit tests.
+**FOR TESTING ONLY**: by default `ORION_EXTENSIONS_DIR=${RUNFILES_DIR}/aspect_silo/plugins/*.axl` for unit tests.
 
 ## TODO:
 

--- a/language/orion/tests/BUILD.bazel
+++ b/language/orion/tests/BUILD.bazel
@@ -18,7 +18,7 @@ BZL_TESTS = [t.replace("/WORKSPACE", "") for t in glob(["bzl/*/WORKSPACE"])]
         ],
         dir = t,
         env = {
-            "ORION_EXTENSIONS": BUILTIN_PLUGINS_DIR,
+            "ORION_EXTENSIONS_DIR": BUILTIN_PLUGINS_DIR,
         },
         gazelle_binary = ":gazelle_orion_binary",
     )

--- a/language/orion/tests/kotlin/BUILD.bazel
+++ b/language/orion/tests/kotlin/BUILD.bazel
@@ -16,7 +16,7 @@ KOTLIN_TESTS = [t.replace("/WORKSPACE", "") for t in glob(["*/WORKSPACE"])]
         ],
         dir = t,
         env = {
-            "ORION_EXTENSIONS": BUILTIN_PLUGINS_DIR,
+            "ORION_EXTENSIONS_DIR": BUILTIN_PLUGINS_DIR,
         },
         gazelle_binary = "//tests:gazelle_orion_binary",
     )

--- a/language/orion/tests/starzelle/BUILD.bazel
+++ b/language/orion/tests/starzelle/BUILD.bazel
@@ -7,7 +7,7 @@ load("@aspect_gazelle//:gazelle.bzl", "gazelle_generation_test")
         name = "%s_test" % t,
         dir = t,
         env = {
-            "ORION_EXTENSIONS": "%s/%s" % (
+            "ORION_EXTENSIONS_DIR": "%s/%s" % (
                 package_name(),
                 t,
             ),

--- a/runner/tests/BUILD.bazel
+++ b/runner/tests/BUILD.bazel
@@ -8,7 +8,7 @@ load("@aspect_gazelle//:gazelle.bzl", "gazelle_generation_test")
         name = "%s_test" % t,
         dir = t,
         env = {
-            "ORION_EXTENSIONS": "%s/%s" % (
+            "ORION_EXTENSIONS_DIR": "%s/%s" % (
                 package_name(),
                 t,
             ),


### PR DESCRIPTION
This way extensions can be loaded via env with something such as:
```
"ORION_EXTENSIONS": ",".join(["$(rootpath %s)" % p for p in plugins]),
```
while the existing method of globing one directory has been renamed to `ORION_EXTENSIONS_DIR`.

See followup https://github.com/aspect-build/aspect-gazelle/pull/89

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
