### PR TITLE
fix: support ORION_EXTENSIONS_DIR being absolute

### DIFF
--- a/language/orion/host.go
+++ b/language/orion/host.go
@@ -109,7 +109,10 @@ func (h *GazelleHost) loadEnvStarzellePlugins() {
 
 	// Load all plugins in the specified subdirectory of the builtinPluginDir
 	if builtinPluginSubdir := os.Getenv("ORION_EXTENSIONS_DIR"); builtinPluginSubdir != "" {
-		builtinDirPlugins, err := filepath.Glob(path.Join(builtinPluginDir, builtinPluginSubdir, "*.axl"))
+		if !path.IsAbs(builtinPluginSubdir) {
+			builtinPluginSubdir = path.Join(builtinPluginDir, builtinPluginSubdir)
+		}
+		builtinDirPlugins, err := filepath.Glob(path.Join(builtinPluginSubdir, "*.axl"))
 		if err != nil {
 			BazelLog.Fatalf("Failed to find builtin plugins: %v", err)
 			return


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:
