### PR TITLE
chore: Rename Starlark Extensions to Aspect Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 
 See [language/js](./language/js).
 
-### Starlark Extensions
+### Aspect Extensions
 
-The [language/host](./language/host) package provides a Gazelle `Language` implementation enabling the use Starlark extensions for BUILD generation.
+The [language/orion](./language/orion) package provides a Gazelle `Language` implementation enabling Aspect Extension Language (AXL, a Starlark dialect) for writing extensions
 
 ## Gazelle Enhancements
 
-Orion provides a variety of enhancements to Gazelle.
+We provide a variety of enhancements to Gazelle.
 
-The [Orion runner](./runner) enables these enhancements automatically, otherwise manual setup (including patching Gazelle) is required.
+The [runner](./runner) enables these enhancements automatically, otherwise manual setup (including patching Gazelle) is required.
 
 ### Gitignore
 
@@ -24,7 +24,7 @@ Support for `.gitignore` when generating BUILD files, enabled by the `# gazelle:
 
 File based caching of any file analysis by Gazelle language implementations.
 
-Basic caching can be enabled by setting the `ASPECT_CONFIGURE_CACHE` environment variable to a path (e.g. `~/.cache/orion.cache`) for loading+persisting the cache between Gazelle runs.
+Basic caching can be enabled by setting the `ASPECT_CONFIGURE_CACHE` environment variable to a path (e.g. `~/.cache/aspect-gazelle.cache`) for loading+persisting the cache between Gazelle runs.
 
 Further functionality includes [watchman](https://facebook.github.io/watchman/) and other utilities for Gazelle language implementations.
 
@@ -32,7 +32,7 @@ See the [common/cache](./common/cache)
 
 ### `--watch` mode
 
-The [Orion runner](./runner) supports a `--watch` mode that uses [watchman](https://facebook.github.io/watchman/) to monitor the filesystem for changes and regenerate BUILD files as needed. This automatically enables the watchman based caching provided by the [common/cache](./common/cache) package.
+The [runner](./runner) supports a `--watch` mode that uses [watchman](https://facebook.github.io/watchman/) to monitor the filesystem for changes and regenerate BUILD files as needed. This automatically enables the watchman based caching provided by the [common/cache](./common/cache) package.
 
 ## Prebuild
 


### PR DESCRIPTION
Updated references from 'Starlark Extensions' to 'Aspect Extensions' and made minor wording adjustments for clarity.

- Orion refers only to our AXL extension bridge, not the whole repo.
- Fix broken link