### PR TITLE
fix: exports of directories containing nested invalid BUILD syntax

### DIFF
--- a/common/walk.go
+++ b/common/walk.go
@@ -56,7 +56,10 @@ func getSourceRegularSubFiles(base, rel string, d walk.DirInfo, files []string) 
 			sdRel = rel + "/" + sdRel
 		}
 
-		sdInfo, _ := walk.GetDirInfo(base + sdRel)
+		sdInfo, err := walk.GetDirInfo(base + sdRel)
+		if err != nil {
+			continue
+		}
 
 		// Recurse into subdirectories that do not have a BUILD file just like a
 		// bazel BUILD glob() would.


### PR DESCRIPTION
Workaround the issue mentioned in https://github.com/bazel-contrib/bazel-gazelle/pull/2212, although I haven't yet reproduced the crash in a test.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
