### PR TITLE
perf: walk lazy-indexed directories in parallel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ bazel_dep(name = "gazelle", version = "0.45.0")
 # Go modules
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//common:go.mod")
-use_repo(go_deps, "com_github_bazelbuild_buildtools", "com_github_bmatcuk_doublestar_v4", "com_github_emirpasic_gods", "com_github_onsi_gomega", "com_github_smacker_go_tree_sitter", "in_gopkg_op_go_logging_v1")
+use_repo(go_deps, "com_github_bazelbuild_buildtools", "com_github_bmatcuk_doublestar_v4", "com_github_emirpasic_gods", "com_github_onsi_gomega", "com_github_smacker_go_tree_sitter", "in_gopkg_op_go_logging_v1", "org_golang_x_sync")
 
 # tree-sitter languages
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing; running with `--index=lazy` on subdirs with many deps that get lazy-walked
