### PR TITLE
perf: cache fs traversal across --watch invocations

### DIFF
--- a/runner/MODULE.bazel
+++ b/runner/MODULE.bazel
@@ -42,6 +42,7 @@ archive_override(
     patch_strip = 1,
     patches = [
         "//patches:bazelbuild_bazel-gazelle_aspect-cli.patch",
+        "//patches:bazelbuild_bazel-gazelle_aspect-watchman.patch",
         "//pkg/git:gazelle-gitignore.patch",
     ],
     strip_prefix = "bazel-gazelle-2de7b829fef136795c68d9d3b8644a379693cf55",
@@ -68,6 +69,7 @@ go_deps2.module_override(
     patch_strip = 1,
     patches = [
         "//patches:bazelbuild_bazel-gazelle_aspect-cli.patch",
+        "//patches:bazelbuild_bazel-gazelle_aspect-watchman.patch",
         "//pkg/git:gazelle-gitignore.patch",
     ],
     path = "github.com/bazelbuild/bazel-gazelle",

--- a/runner/patches/bazelbuild_bazel-gazelle_aspect-watchman.patch
+++ b/runner/patches/bazelbuild_bazel-gazelle_aspect-watchman.patch
@@ -1,0 +1,17 @@
+diff --git a/walk/walk.go b/walk/walk.go
+index 0e59bcf..b8d774c 100644
+--- a/walk/walk.go
++++ b/walk/walk.go
+@@ -373,6 +373,12 @@ func newWalker(c *config.Config, cexts []config.Configurer, dirs []string, mode
+ 		relsToVisitSeen: make(map[string]struct{}),
+ 	}
+ 
++	// PATCH(caching): additional aspect-gazelle caching of walker
++	if c.Exts["aspect:walkCache:load"] != nil {
++		walkCacheLoad := c.Exts["aspect:walkCache:load"].(func(m interface{}))
++		walkCacheLoad(&w.cache.entryMap)
++	}
++
+ 	// Asynchronously populate the walker cache in the background.
+ 	go w.populateCache()
+ 

--- a/runner/pkg/watchman/BUILD.bazel
+++ b/runner/pkg/watchman/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     ],
     embed = [":watchman"],
     tags = ["manual"],  # TODO: we need watchman in our runners.
+    deps = ["@gazelle//config"],
 )
 
 # At least make sure watch tests can build despite being tagged as manual

--- a/runner/pkg/watchman/cache_test.go
+++ b/runner/pkg/watchman/cache_test.go
@@ -3,6 +3,8 @@ package watchman
 import (
 	"os"
 	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
 )
 
 func TestLoadOrStoreFile(t *testing.T) {
@@ -22,7 +24,7 @@ func TestLoadOrStoreFile(t *testing.T) {
 	defer w.Stop()
 	defer w.Close()
 
-	c := newWatchmanCache(w, getTempFile(t))
+	c := newWatchmanCache(config.New(), w, getTempFile(t))
 
 	computes := 0
 	compute := func(path string, content []byte) (any, error) {
@@ -73,7 +75,7 @@ func TestLoadOrStoreFileSymlink(t *testing.T) {
 	defer w.Stop()
 	defer w.Close()
 
-	c := newWatchmanCache(w, getTempFile(t))
+	c := newWatchmanCache(config.New(), w, getTempFile(t))
 
 	computes := 0
 	compute := func(path string, content []byte) (any, error) {


### PR DESCRIPTION
When using caching things like tree-sitter queries the slowest thing remaining is gazelle traversing the fs, essentially doing `ReadDir` and parsing the BUILDs in each dir.

This patches gazelle to:
1. `aspect_gazelle_runner` gets a reference to the gazelle fs cache, save it for next time gazelle runs
2. invalidate saved fs reads based on the list of files changed from watchman
3. populate that gazelle fs cache based on previous invocations, this is done before gazelle starts to traverse the fs

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing; run `configure --watch` and trigger an incremental invocation, ensure it preloads the fs cache
