### PR TITLE
feat: add explicit SUBSCRIBE message to initiate subscriptions

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -238,8 +238,8 @@ func (p *GazelleRunner) Watch(watchAddress string, cmd GazelleCommand, mode Gaze
 	))
 	defer t.End()
 
-	// Subscribe to further changes
-	for cs, err := range watch.AwaitCycle() {
+	// Subscribe to further changes to all sources
+	for cs, err := range watch.Subscribe(ibp.WatchOptions{Type: ibp.WatchTypeSources}) {
 		if err != nil {
 			fmt.Printf("ERROR: watch cycle error: %v\n", err)
 			return err


### PR DESCRIPTION
This way binaries such as `aspect_gazelle_runner` or formatters can specify they want to receive CYCLE events for any source changes, not only runfiles changes like today.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing
