### PR TITLE
fix: file deletions in --watch CYCLE messages

### DIFF
--- a/runner/pkg/ibp/client.go
+++ b/runner/pkg/ibp/client.go
@@ -150,9 +150,13 @@ func convertWireCycle(msg map[string]interface{}) (CycleSourcesMessage, error) {
 
 	sources := make(SourceInfoMap, len(msg["sources"].(map[string]interface{})))
 	for k, v := range msg["sources"].(map[string]interface{}) {
-		sources[k] = &SourceInfo{
-			IsSymlink: readOptionalBool(v.(map[string]interface{}), "is_symlink"),
-			IsSource:  readOptionalBool(v.(map[string]interface{}), "is_source"),
+		if v == nil {
+			sources[k] = nil
+		} else {
+			sources[k] = &SourceInfo{
+				IsSymlink: readOptionalBool(v.(map[string]interface{}), "is_symlink"),
+				IsSource:  readOptionalBool(v.(map[string]interface{}), "is_source"),
+			}
 		}
 	}
 


### PR DESCRIPTION
When converting the CYCLE json into structs on the go side. This is the receiver of cycle events when using gazelle `--watch`.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- Manual testing
