### PR TITLE
feat: ts_project_test

### DIFF
--- a/language/js/generate.go
+++ b/language/js/generate.go
@@ -561,6 +561,9 @@ func (ts *typeScriptLang) addProjectRule(cfg *JsGazelleConfig, tsconfigRel strin
 	existing := ruleUtils.GetFileRuleByName(args, targetName)
 
 	ruleKind := TsProjectKind
+	if group.testonly {
+		ruleKind = TsProjectTestKind
+	}
 	if !hasTranspiledSources(info.sources) {
 		ruleKind = JsLibraryKind
 	}

--- a/language/js/kinds.go
+++ b/language/js/kinds.go
@@ -173,7 +173,7 @@ func (h *typeScriptLang) ApparentLoads(moduleToApparentName func(string) string)
 			Name: "@" + tsModName + "//ts:defs.bzl",
 			Symbols: []string{
 				TsProjectKind,
-+				TsProjectTestKind,
+				TsProjectTestKind,
 				TsConfigKind,
 			},
 		},

--- a/language/js/kinds.go
+++ b/language/js/kinds.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	TsProjectKind         = "ts_project"
+	TsProjectTestKind     = "ts_project_test"
 	TsProtoLibraryKind    = "ts_proto_library"
 	JsLibraryKind         = "js_library"
 	JsBinaryKind          = "js_binary"
@@ -21,7 +22,7 @@ const (
 	NpmRepositoryName     = "npm"
 )
 
-var sourceRuleKinds = treeset.NewWithStringComparator(TsProjectKind, JsLibraryKind, TsProtoLibraryKind)
+var sourceRuleKinds = treeset.NewWithStringComparator(TsProjectKind, TsProjectTestKind, JsLibraryKind, TsProtoLibraryKind)
 
 // Kinds returns a map that maps rule names (kinds) and information on how to
 // match and merge attributes that may be found in rules of those kinds.
@@ -57,6 +58,19 @@ var tsKinds = map[string]rule.KindInfo{
 			"preserve_jsx":          true,
 			"out_dir":               true,
 			"root_dir":              true,
+		},
+		ResolveAttrs: map[string]bool{
+			"deps": true,
+		},
+	},
+	TsProjectTestKind: {
+		MatchAny: false,
+		NonEmptyAttrs: map[string]bool{
+			"srcs": true,
+		},
+		SubstituteAttrs: map[string]bool{},
+		MergeableAttrs: map[string]bool{
+			"srcs": true,
 		},
 		ResolveAttrs: map[string]bool{
 			"deps": true,
@@ -159,6 +173,7 @@ func (h *typeScriptLang) ApparentLoads(moduleToApparentName func(string) string)
 			Name: "@" + tsModName + "//ts:defs.bzl",
 			Symbols: []string{
 				TsProjectKind,
++				TsProjectTestKind,
 				TsConfigKind,
 			},
 		},

--- a/language/js/resolve.go
+++ b/language/js/resolve.go
@@ -50,6 +50,8 @@ func (ts *typeScriptLang) Imports(c *config.Config, r *rule.Rule, f *rule.File) 
 		return ts.tsconfigImports(r, f)
 	case TsProjectKind:
 		fallthrough
+	case TsProjectTestKind:
+		fallthrough
 	case JsLibraryKind:
 		return ts.sourceFileImports(c, r, f)
 	}
@@ -218,6 +220,7 @@ func (ts *typeScriptLang) Embeds(r *rule.Rule, from label.Label) []label.Label {
 	BazelLog.Debugf("Embeds(%s): '//%s:%s'", LanguageName, from.Pkg, r.Name())
 
 	switch r.Kind() {
+	case TsProjectKind, TsProjectTestKind:
 	case TsProjectKind:
 		srcs := r.AttrStrings("srcs")
 		tsEmbeds := make([]label.Label, 0, len(srcs))
@@ -297,7 +300,7 @@ func (ts *typeScriptLang) Resolve(
 
 	// TsProject imports are resolved as deps
 	switch r.Kind() {
-	case TsProjectKind, JsLibraryKind, TsConfigKind, TsProtoLibraryKind:
+	case TsProjectKind, TsProjectTestKind, JsLibraryKind, TsConfigKind, TsProtoLibraryKind:
 		deps := common.NewLabelSet(from)
 
 		// Support this target representing a project or a package

--- a/language/js/resolve.go
+++ b/language/js/resolve.go
@@ -221,7 +221,6 @@ func (ts *typeScriptLang) Embeds(r *rule.Rule, from label.Label) []label.Label {
 
 	switch r.Kind() {
 	case TsProjectKind, TsProjectTestKind:
-	case TsProjectKind:
 		srcs := r.AttrStrings("srcs")
 		tsEmbeds := make([]label.Label, 0, len(srcs))
 


### PR DESCRIPTION
    This is a patch we have been carrying for two years
    It allows a user to use `map_kind` when it comes across
    test targets and generate a test target in addition to
    the source target ts_project. This allows apps to support
    things like jest or vitest target generation

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

### Test plan

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
