### PR TITLE
feat: allow watchman subscribers to defer vs drop changes during subscribe callback

### DIFF
--- a/runner/pkg/watchman/watch_test.go
+++ b/runner/pkg/watchman/watch_test.go
@@ -83,7 +83,7 @@ func TestSubscribe(t *testing.T) {
 
 	changeset := make(chan ChangeSet)
 	go func() {
-		for cs := range w.Subscribe(context.TODO(), "") {
+		for cs := range w.Subscribe(context.TODO()) {
 			t.Log(cs)
 			if len(cs.Paths) == 0 {
 				break


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:
