### PR TITLE
feat: support custom aspect_gazelle(gazelle) binary

### DIFF
--- a/runner/def.bzl
+++ b/runner/def.bzl
@@ -53,13 +53,14 @@ def aspect_gazelle(languages = [], extensions = [], **kwargs):
         extensions: A list of labels pointing to Aspect Gazelle Orion Starlark extensions
             to load. These extensions provide additional BUILD file generation logic.
         **kwargs: Additional arguments passed directly to the underlying `gazelle()` macro including:
+            - `gazelle`: The label of the Gazelle binary to use such as a prebuilt (default: "@aspect_gazelle_runner//bin/gazelle:gazelle")
             - `command`: The Gazelle command to run (e.g., "update", "fix")
             - `mode`: The Gazelle mode (e.g., "diff", "update", "fix")
             - `args`: Additional command-line arguments for Gazelle
     """
 
     gazelle(
-        gazelle = Label("@aspect_gazelle_runner//bin/gazelle:gazelle"),
+        gazelle = kwargs.pop("gazelle", Label("@aspect_gazelle_runner//bin/gazelle:gazelle")),
         env = kwargs.pop("env", {}) | {
             "ENABLE_LANGUAGES": ",".join(languages),
             "ORION_EXTENSIONS": ",".join(["$(rootpath %s)" % p for p in extensions]),


### PR DESCRIPTION
This macro was intended to be used instead of users manually referencing gazelle and hides things like the `ENABLE_LANGUAGES` and `ORION_EXTENSIONS` env vars etc. This is where we need to add proper support for prebuilds when releases are tagged still.

This is where we could WARN or FAIL if [proto is not first](https://github.com/aspect-build/aspect-gazelle/issues/131) etc.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
