### PR TITLE
refactor: change builtin copy_to_bin kind to bazel-lib

### DIFF
--- a/language/orion/builtin.go
+++ b/language/orion/builtin.go
@@ -14,10 +14,10 @@ var builtinKinds = []plugin.RuleKind{
 		},
 	},
 
-	// @aspect_bazel_lib
+	// @bazel_lib
 	plugin.RuleKind{
 		Name: "copy_to_bin",
-		From: "@aspect_bazel_lib//lib:copy_to_bin.bzl",
+		From: "@bazel_lib//lib:copy_to_bin.bzl",
 		KindInfo: plugin.KindInfo{
 			NonEmptyAttrs:  []string{"srcs"},
 			MergeableAttrs: []string{"srcs"},

--- a/language/orion/tests/starzelle/builtins/fresh/BUILD.out
+++ b/language/orion/tests/starzelle/builtins/fresh/BUILD.out
@@ -1,4 +1,4 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 
 copy_to_bin(
     name = "ctb",

--- a/language/orion/tests/starzelle/builtins/keep/BUILD.in
+++ b/language/orion/tests/starzelle/builtins/keep/BUILD.in
@@ -1,4 +1,4 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 
 copy_to_bin(
     name = "ctb",

--- a/language/orion/tests/starzelle/builtins/keep/BUILD.out
+++ b/language/orion/tests/starzelle/builtins/keep/BUILD.out
@@ -1,4 +1,4 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 
 copy_to_bin(
     name = "ctb",

--- a/language/orion/tests/starzelle/builtins/merged/BUILD.in
+++ b/language/orion/tests/starzelle/builtins/merged/BUILD.in
@@ -1,4 +1,4 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 
 copy_to_bin(
     name = "ctb",

--- a/language/orion/tests/starzelle/builtins/merged/BUILD.out
+++ b/language/orion/tests/starzelle/builtins/merged/BUILD.out
@@ -1,4 +1,4 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 
 copy_to_bin(
     name = "ctb",

--- a/language/orion/tests/starzelle/builtins/now-empty/BUILD.in
+++ b/language/orion/tests/starzelle/builtins/now-empty/BUILD.in
@@ -1,4 +1,4 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 
 copy_to_bin(
     name = "ctb",

--- a/language/orion/tests/starzelle/builtins/sub/first/BUILD.out
+++ b/language/orion/tests/starzelle/builtins/sub/first/BUILD.out
@@ -1,4 +1,4 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 
 copy_to_bin(
     name = "ctb",

--- a/language/orion/tests/starzelle/noop/builtins/BUILD.in
+++ b/language/orion/tests/starzelle/noop/builtins/BUILD.in
@@ -1,4 +1,4 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 
 filegroup(
     name = "x",

--- a/language/orion/tests/starzelle/noop/builtins/BUILD.out
+++ b/language/orion/tests/starzelle/noop/builtins/BUILD.out
@@ -1,4 +1,4 @@
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 
 filegroup(
     name = "x",


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

By default generated `copy_to_bin` now gets loaded from `bazel_lib` instead of `aspect_bazel_lib`

### Test plan

- Covered by existing test cases
