### PR TITLE
fix: remove resolution suggestions from not-found error messages

### DIFF
--- a/language/js/resolve.go
+++ b/language/js/resolve.go
@@ -419,16 +419,8 @@ func (ts *typeScriptLang) resolveImports(
 				BazelLog.Debugf("import %q for target %v not found", imp.ImportPath, from)
 
 				notFound := fmt.Errorf(
-					"Import %[1]q from %[2]q is an unknown dependency. Possible solutions:\n"+
-						"\t1. Instruct Gazelle to resolve to a known dependency using a directive:\n"+
-						"\t\t# aspect:resolve [src-lang] %[5]s import-string label\n"+
-						"\t\t   or\n"+
-						"\t\t# aspect:resolve_regex [src-lang] %[5]s import-string-regex label\n"+
-						"\t\t   or\n"+
-						"\t\t# aspect:js_resolve import-string-glob label\n"+
-						"\t2. Ignore the dependency using the '# aspect:%[3]s %[1]s' directive.\n"+
-						"\t3. Disable Gazelle resolution validation using '# aspect:%[4]s off'",
-					imp.ImportPath, imp.SourcePath, Directive_IgnoreImports, Directive_ValidateImportStatements, LanguageName,
+					"Import %q from %q is an unknown %s dependency",
+					imp.ImportPath, imp.SourcePath, LanguageName,
 				)
 				resolutionErrors = append(resolutionErrors, notFound)
 			}

--- a/language/js/tests/tsx_css_not-found/expectedStderr.txt
+++ b/language/js/tests/tsx_css_not-found/expectedStderr.txt
@@ -1,21 +1,5 @@
 Failed to validate dependencies for target "@tsx_css_not-found//:tsx_css_not-found":
 
-Import "/abs/styles.css" from "main.tsx" is an unknown dependency. Possible solutions:
-	1. Instruct Gazelle to resolve to a known dependency using a directive:
-		# aspect:resolve [src-lang] js import-string label
-		   or
-		# aspect:resolve_regex [src-lang] js import-string-regex label
-		   or
-		# aspect:js_resolve import-string-glob label
-	2. Ignore the dependency using the '# aspect:js_ignore_imports /abs/styles.css' directive.
-	3. Disable Gazelle resolution validation using '# aspect:js_validate_import_statements off'
+Import "/abs/styles.css" from "main.tsx" is an unknown js dependency
 
-Import "./styles.css" from "main.tsx" is an unknown dependency. Possible solutions:
-	1. Instruct Gazelle to resolve to a known dependency using a directive:
-		# aspect:resolve [src-lang] js import-string label
-		   or
-		# aspect:resolve_regex [src-lang] js import-string-regex label
-		   or
-		# aspect:js_resolve import-string-glob label
-	2. Ignore the dependency using the '# aspect:js_ignore_imports ./styles.css' directive.
-	3. Disable Gazelle resolution validation using '# aspect:js_validate_import_statements off'
+Import "./styles.css" from "main.tsx" is an unknown js dependency

--- a/language/js/tests/validate_import_statements/expectedStderr.txt
+++ b/language/js/tests/validate_import_statements/expectedStderr.txt
@@ -1,21 +1,5 @@
 Failed to validate dependencies for target "@validate_import_statements//:validate_import_statements":
 
-Import "bad-import" from "main.ts" is an unknown dependency. Possible solutions:
-	1. Instruct Gazelle to resolve to a known dependency using a directive:
-		# aspect:resolve [src-lang] js import-string label
-		   or
-		# aspect:resolve_regex [src-lang] js import-string-regex label
-		   or
-		# aspect:js_resolve import-string-glob label
-	2. Ignore the dependency using the '# aspect:js_ignore_imports bad-import' directive.
-	3. Disable Gazelle resolution validation using '# aspect:js_validate_import_statements off'
+Import "bad-import" from "main.ts" is an unknown js dependency
 
-Import "bad-import2" from "main.ts" is an unknown dependency. Possible solutions:
-	1. Instruct Gazelle to resolve to a known dependency using a directive:
-		# aspect:resolve [src-lang] js import-string label
-		   or
-		# aspect:resolve_regex [src-lang] js import-string-regex label
-		   or
-		# aspect:js_resolve import-string-glob label
-	2. Ignore the dependency using the '# aspect:js_ignore_imports bad-import2' directive.
-	3. Disable Gazelle resolution validation using '# aspect:js_validate_import_statements off'
+Import "bad-import2" from "main.ts" is an unknown js dependency

--- a/language/js/tests/validate_import_statements_warn/expectedStderr.txt
+++ b/language/js/tests/validate_import_statements_warn/expectedStderr.txt
@@ -1,11 +1,3 @@
 Warning: Failed to validate dependencies for target "@validate_import_statements_warn//:validate_import_statements_warn":
 
-Import "bad-import" from "main.ts" is an unknown dependency. Possible solutions:
-	1. Instruct Gazelle to resolve to a known dependency using a directive:
-		# aspect:resolve [src-lang] js import-string label
-		   or
-		# aspect:resolve_regex [src-lang] js import-string-regex label
-		   or
-		# aspect:js_resolve import-string-glob label
-	2. Ignore the dependency using the '# aspect:js_ignore_imports bad-import' directive.
-	3. Disable Gazelle resolution validation using '# aspect:js_validate_import_statements off'
+Import "bad-import" from "main.ts" is an unknown js dependency

--- a/language/kotlin/resolver.go
+++ b/language/kotlin/resolver.go
@@ -109,10 +109,8 @@ func (kt *kotlinLang) resolveImports(
 			BazelLog.Debugf("import %q for target %v not found", mod.Imp, from)
 
 			notFound := fmt.Errorf(
-				"Import %[1]q from %[2]q is an unknown dependency. Possible solutions:\n"+
-					"\t1. Instruct Gazelle to resolve to a known dependency using a directive:\n"+
-					"\t\t# gazelle:resolve [src-lang] kotlin import-string label\n",
-				mod.Imp, mod.SourcePath,
+				"Import %q from %q is an unknown %s dependency",
+				mod.Imp, mod.SourcePath, LanguageName,
 			)
 
 			errs = append(errs, notFound)

--- a/language/kotlin/tests/unknown_imports/expectedStderr.txt
+++ b/language/kotlin/tests/unknown_imports/expectedStderr.txt
@@ -1,4 +1,1 @@
-Resolution error Import "lib.not" from "lib.kt" is an unknown dependency. Possible solutions:
-	1. Instruct Gazelle to resolve to a known dependency using a directive:
-		# gazelle:resolve [src-lang] kotlin import-string label
-
+Resolution error Import "lib.not" from "lib.kt" is an unknown kotlin dependency

--- a/language/orion/resolver.go
+++ b/language/orion/resolver.go
@@ -197,11 +197,8 @@ func (re *GazelleHost) resolveImports(
 			BazelLog.Debugf("import %q for target %v not found", imp.Id, from)
 
 			if !imp.Optional {
-				notFound := fmt.Errorf(
-					"Import %[1]q (provider %[2]q) from %[3]q is an unknown dependency. Possible solutions:\n"+
-						"\t1. Instruct Gazelle to resolve to a known dependency using a directive:\n"+
-						"\t\t# aspect:resolve [src-lang] %[4]s import-string label\n",
-					imp.Id, imp.Provider, imp.From, pluginId,
+				notFound := fmt.Errorf("Import %q (provider %q) from %q is an unknown dependency",
+					imp.Id, imp.Provider, imp.From,
 				)
 
 				errs = append(errs, notFound)

--- a/language/orion/tests/kotlin/unknown_imports/expectedStderr.txt
+++ b/language/orion/tests/kotlin/unknown_imports/expectedStderr.txt
@@ -1,3 +1,1 @@
-Resolution Error: Import "lib.not" (provider "kt") from "lib.kt" is an unknown dependency. Possible solutions:
-	1. Instruct Gazelle to resolve to a known dependency using a directive:
-		# aspect:resolve [src-lang] kotlin import-string label
+Resolution Error: Import "lib.not" (provider "kt") from "lib.kt" is an unknown dependency

--- a/language/orion/tests/starzelle/imports-missing/expectedStderr.txt
+++ b/language/orion/tests/starzelle/imports-missing/expectedStderr.txt
@@ -1,7 +1,2 @@
-Resolution Error: Import "b" (provider "x") from "sub:x_lib" is an unknown dependency. Possible solutions:
-	1. Instruct Gazelle to resolve to a known dependency using a directive:
-		# aspect:resolve [src-lang] imports-missing import-string label
-
-Import "d" (provider "x") from "" is an unknown dependency. Possible solutions:
-	1. Instruct Gazelle to resolve to a known dependency using a directive:
-		# aspect:resolve [src-lang] imports-missing import-string label
+Resolution Error: Import "b" (provider "x") from "sub:x_lib" is an unknown dependency
+Import "d" (provider "x") from "" is an unknown dependency

--- a/runner/tests/imports-missing/expectedStderr.txt
+++ b/runner/tests/imports-missing/expectedStderr.txt
@@ -1,7 +1,2 @@
-aspect-gazelle: Error running gazelle: Resolution Error: Import "b" (provider "x") from "sub:x_lib" is an unknown dependency. Possible solutions:
-	1. Instruct Gazelle to resolve to a known dependency using a directive:
-		# aspect:resolve [src-lang] imports-missing import-string label
-
-Import "d" (provider "x") from "" is an unknown dependency. Possible solutions:
-	1. Instruct Gazelle to resolve to a known dependency using a directive:
-		# aspect:resolve [src-lang] imports-missing import-string label
+aspect-gazelle: Error running gazelle: Resolution Error: Import "b" (provider "x") from "sub:x_lib" is an unknown dependency
+Import "d" (provider "x") from "" is an unknown dependency


### PR DESCRIPTION
The "suggestions" provided in these error messages are often not the ideal solution and lead people (and robots) to these non-ideal solutions.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Resolution errors for js, kotlin and orion plugin imports no longer output "suggestions" for resolution such as the use of `# gazelle:resolve` or `# gazelle:ignore`.

### Test plan

- Covered by existing test cases
