### PR TITLE
fix: bump tree-sitter-kotlin to fix fun interface parsing

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -63,9 +63,9 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 """,
-    sha256 = "7dd60975786bf9cb4be6a5176f5ccb5fed505f9929a012da30762505b1015669",
-    strip_prefix = "tree-sitter-kotlin-0.3.8",
-    urls = ["https://github.com/fwcd/tree-sitter-kotlin/archive/0.3.8.tar.gz"],
+    sha256 = "666c67f4486d6f7ebeb6418a956f3d7599b3e200e42fe583312c92182ce731d0",
+    strip_prefix = "tree-sitter-kotlin-6b9788578ae23a1bc7c87e8d564e0daf7671dee3",
+    urls = ["https://github.com/fwcd/tree-sitter-kotlin/archive/6b9788578ae23a1bc7c87e8d564e0daf7671dee3.tar.gz"],
 )
 
 http_archive(

--- a/language/kotlin/parser/parser_test.go
+++ b/language/kotlin/parser/parser_test.go
@@ -52,6 +52,21 @@ import /* fdsa */ d/* asdf */.* // w
 		pkg:      "x",
 		imports:  []string{"a", "c", "d"},
 	},
+	// Fun interfaces (SAM): https://github.com/fwcd/tree-sitter-kotlin/issues/87
+	{
+		desc: "fun-interface",
+		kt: `package com.example
+
+import com.example.dep.Foo
+
+fun interface MyHandler {
+    fun handle(value: String): Boolean
+}
+`,
+		filename: "handler.kt",
+		pkg:      "com.example",
+		imports:  []string{"com.example.dep"},
+	},
 	// Value classes: https://github.com/fwcd/tree-sitter-kotlin/commit/80834a15154448cfa795bfa6b8be3559af1753fc
 	{
 		desc: "value-classes",


### PR DESCRIPTION
## Summary

- Bump `tree-sitter-kotlin` from v0.3.8 to the latest commit ([`6b97885`](https://github.com/fwcd/tree-sitter-kotlin/commit/6b9788578ae23a1bc7c87e8d564e0daf7671dee3)) which includes a fix for `fun interface` (SAM interface) parsing ([fwcd/tree-sitter-kotlin#87](https://github.com/fwcd/tree-sitter-kotlin/issues/87))
- Add a test case for `fun interface` to the Kotlin parser tests

## Motivation

Kotlin files using `fun interface` (a core language feature since Kotlin 1.4) cause the tree-sitter-kotlin v0.3.8 grammar to produce parse errors. When this happens, the parser fails to extract imports and package declarations, leading to incorrect or missing BUILD rules.

This is a simpler alternative to #191 -- instead of replacing the tree-sitter parser, we just bump to a version that includes the fix.

## Test plan

- Added `fun-interface` test case that verifies package and import extraction from a file containing `fun interface`
- All 19 Kotlin Bazel test targets pass locally


Made with [Cursor](https://cursor.com)