### PR TITLE
refactor: apply golang modernize tool

### DIFF
--- a/common/cache/disk.go
+++ b/common/cache/disk.go
@@ -28,12 +28,12 @@ func NewDiskCache(cacheFilePath string) Cache {
 func init() {
 	// Register some basic types for gob serialization so languages
 	// only have to register custom types.
-	gob.Register(map[string]interface{}{})
+	gob.Register(map[string]any{})
 	gob.Register(map[string]string{})
 	gob.Register(map[string][]string{})
-	gob.Register(map[string]map[string]interface{}{})
+	gob.Register(map[string]map[string]any{})
 	gob.Register(map[string]map[string]string{})
-	gob.Register([]interface{}{})
+	gob.Register([]any{})
 	gob.Register(persistedCacheInfo{})
 }
 
@@ -94,9 +94,9 @@ func (c *diskCache) write() {
 	defer cacheWriter.Close()
 
 	m := make(map[string]map[string]any)
-	c.new.Range(func(p, e interface{}) bool {
+	c.new.Range(func(p, e any) bool {
 		ce := e.(*cacheEntry)
-		ce.values.Range(func(k, v interface{}) bool {
+		ce.values.Range(func(k, v any) bool {
 			if _, ok := m[ce.contentHash]; !ok {
 				m[ce.contentHash] = make(map[string]any)
 			}

--- a/common/error.go
+++ b/common/error.go
@@ -20,21 +20,21 @@ const gazelleContextCancelKey = "aspect:context.cancel"
 //
 // If possible, the gazelle execution is cancelled. If cancellation is not setup, the
 // process may exit.
-func MisconfiguredErrorf(c *config.Config, msg string, args ...interface{}) {
+func MisconfiguredErrorf(c *config.Config, msg string, args ...any) {
 	cancelOrFatal(c, msg, args...)
 }
 
-func GenerationErrorf(c *config.Config, msg string, args ...interface{}) {
+func GenerationErrorf(c *config.Config, msg string, args ...any) {
 	cancelOrFatal(c, msg, args...)
 }
 
-func ImportErrorf(c *config.Config, msg string, args ...interface{}) {
+func ImportErrorf(c *config.Config, msg string, args ...any) {
 	// TODO: only log if running in non-strict mode?
 
 	cancelOrFatal(c, msg, args...)
 }
 
-func cancelOrFatal(c *config.Config, msg string, args ...interface{}) {
+func cancelOrFatal(c *config.Config, msg string, args ...any) {
 	if ctxCancel, ctxExists := c.Exts[gazelleContextCancelKey]; ctxExists {
 		ctxCancel.(context.CancelCauseFunc)(fmt.Errorf(msg, args...))
 		return

--- a/common/logger/logger.go
+++ b/common/logger/logger.go
@@ -89,28 +89,28 @@ func GetOutput() io.Writer {
 	return logger.Writer()
 }
 
-func Tracef(format string, args ...interface{}) {
+func Tracef(format string, args ...any) {
 	if level > TraceLevel {
 		return
 	}
 	logger.Printf(format, args...)
 }
 
-func Debugf(format string, args ...interface{}) {
+func Debugf(format string, args ...any) {
 	if level > DebugLevel {
 		return
 	}
 	logger.Printf(format, args...)
 }
 
-func Infof(format string, args ...interface{}) {
+func Infof(format string, args ...any) {
 	if level > InfoLevel {
 		return
 	}
 	logger.Printf(format, args...)
 }
 
-func Warnf(format string, args ...interface{}) {
+func Warnf(format string, args ...any) {
 	if level > WarnLevel {
 		return
 	}
@@ -123,14 +123,14 @@ func Error(msg string) {
 	}
 	logger.Print(msg)
 }
-func Errorf(format string, args ...interface{}) {
+func Errorf(format string, args ...any) {
 	if level > ErrorLevel {
 		return
 	}
 	logger.Printf(format, args...)
 }
 
-func Fatalf(format string, args ...interface{}) {
+func Fatalf(format string, args ...any) {
 	logger.Fatalf(format+"\n", args...)
 }
 func Fatal(msg string) {

--- a/common/treesitter/parser.go
+++ b/common/treesitter/parser.go
@@ -56,8 +56,7 @@ const (
 	Ruby                        = "ruby"
 )
 
-type Language interface {
-}
+type Language any
 
 func NewLanguage(grammar LanguageGrammar, langPtr unsafe.Pointer) Language {
 	return &treeLanguage{

--- a/common/treesitter/queries.go
+++ b/common/treesitter/queries.go
@@ -13,8 +13,7 @@ import (
 
 var ErrorsQuery = `(ERROR) @error`
 
-type TreeQuery interface {
-}
+type TreeQuery any
 
 // A cache of parsed queries per language
 var queryCache = sync.Map{}

--- a/language/js/node/package.go
+++ b/language/js/node/package.go
@@ -13,7 +13,7 @@ type npmPackageJSON struct {
 	Main string `json:"main"`
 
 	// exports: https://nodejs.org/docs/latest-v22.x/api/packages.html#exports
-	Exports interface{} `json:"exports"`
+	Exports any `json:"exports"`
 
 	// types/typings: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package
 	Types   string `json:"types"`
@@ -51,7 +51,7 @@ func ParsePackageJsonImports(packageJsonReader io.Reader) ([]string, error) {
 		case string:
 			// Single export
 			imports = append(imports, path.Clean(exports))
-		case map[string]interface{}:
+		case map[string]any:
 			// Subpath exports
 			for exportKey, export := range exports {
 				switch e := export.(type) {
@@ -68,7 +68,7 @@ func ParsePackageJsonImports(packageJsonReader io.Reader) ([]string, error) {
 					// 	 }
 					// }
 					break
-				case map[string]interface{}:
+				case map[string]any:
 					// Conditional subpath export
 					for subEKey, subE := range e {
 						switch subE := subE.(type) {
@@ -82,7 +82,7 @@ func ParsePackageJsonImports(packageJsonReader io.Reader) ([]string, error) {
 					BazelLog.Warnf("Unknown package.json exports.%s type: %T", exportKey, export)
 				}
 			}
-		case []interface{}:
+		case []any:
 			// Array of subpath exports
 			for i, subE := range exports {
 				switch subE := subE.(type) {

--- a/language/js/node/paths.go
+++ b/language/js/node/paths.go
@@ -25,12 +25,12 @@ func ParseImportPath(imp string) (string, string) {
 	}
 
 	// Imports of package-like paths
-	pkgEnd := strings.IndexByte(imp, '/')
-	if pkgEnd == -1 {
+	before, after, ok := strings.Cut(imp, "/")
+	if !ok {
 		return imp, ""
 	}
 
-	return imp[:pkgEnd], imp[pkgEnd+1:]
+	return before, after
 }
 
 func ToAtTypesPackage(pkg string) string {

--- a/language/js/pnpm/parser_v5.go
+++ b/language/js/pnpm/parser_v5.go
@@ -3,6 +3,7 @@ package gazelle
 import (
 	"fmt"
 	"io"
+	"maps"
 
 	"gopkg.in/yaml.v3"
 )
@@ -97,9 +98,7 @@ func mergeDependenciesV5(d ...packageInfoV5) map[string]string {
 	result := make(map[string]string)
 
 	for _, m := range d {
-		for k, v := range m {
-			result[k] = v
-		}
+		maps.Copy(result, m)
 	}
 
 	return result

--- a/language/js/typescript/tsconfig.go
+++ b/language/js/typescript/tsconfig.go
@@ -487,8 +487,8 @@ func (c TsConfig) ExpandPaths(from, p string) []string {
 	// Check for pattern matches next
 	possibleMatches := make(matchArray, 0)
 	for key, originalPaths := range pathMap {
-		if starIndex := strings.IndexByte(key, '*'); starIndex != -1 {
-			prefix, suffix := key[:starIndex], key[starIndex+1:]
+		if before, after, ok := strings.Cut(key, "*"); ok {
+			prefix, suffix := before, after
 
 			if strings.HasPrefix(p, prefix) && strings.HasSuffix(p, suffix) {
 				possibleMatches = append(possibleMatches, match{

--- a/language/orion/plugin/plugin.go
+++ b/language/orion/plugin/plugin.go
@@ -72,20 +72,20 @@ type KindInfo struct {
 type Property struct {
 	Name         string // TODO: drop because it's always specified in a map[Name]?
 	PropertyType PropertyType
-	Default      interface{}
+	Default      any
 }
 
 type PropertyValues struct {
-	values map[string]interface{}
+	values map[string]any
 }
 
 func NewPropertyValues() PropertyValues {
 	return PropertyValues{
-		values: make(map[string]interface{}),
+		values: make(map[string]any),
 	}
 }
 
-func (pv *PropertyValues) Add(name string, value interface{}) {
+func (pv *PropertyValues) Add(name string, value any) {
 	pv.values[name] = value
 }
 

--- a/language/orion/plugin/plugin.star.go
+++ b/language/orion/plugin/plugin.star.go
@@ -249,7 +249,7 @@ func addTarget(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tupl
 
 	// TODO: don't create new clones of map/arrays every time
 
-	var attrs map[string]interface{}
+	var attrs map[string]any
 	if starAttrs != nil {
 		attrs, err = starUtils.ReadMap2(starAttrs, readTargetAttributeValue)
 		if err != nil {

--- a/language/orion/plugin/queries.go
+++ b/language/orion/plugin/queries.go
@@ -9,7 +9,7 @@ type NamedQueries map[string]QueryDefinition
 
 // Intermediate object to hold a query key+result in a single struct.
 type QueryProcessorResult struct {
-	Result interface{}
+	Result any
 	Key    string
 }
 
@@ -27,7 +27,7 @@ const (
 type QueryDefinition struct {
 	Filter    []string
 	QueryType QueryType
-	Params    interface{}
+	Params    any
 
 	FilterExpr common.GlobExpr
 }
@@ -41,7 +41,7 @@ func (q QueryDefinition) Match(f string) bool {
 }
 
 // TODO: better naming?  QueryMapping?
-type QueryResults map[string]interface{}
+type QueryResults map[string]any
 
 // Multiple matches
 type QueryMatches []QueryMatch
@@ -51,11 +51,11 @@ type QueryCapture map[string]string
 
 // A single match.
 type QueryMatch struct {
-	Result   interface{}
+	Result   any
 	Captures QueryCapture
 }
 
-func NewQueryMatch(captures QueryCapture, result interface{}) QueryMatch {
+func NewQueryMatch(captures QueryCapture, result any) QueryMatch {
 	return QueryMatch{Captures: captures, Result: result}
 }
 

--- a/language/orion/plugin/target.go
+++ b/language/orion/plugin/target.go
@@ -29,13 +29,13 @@ type TargetSymbol struct {
 type TargetDeclaration struct {
 	Name  string
 	Kind  string
-	Attrs map[string]interface{}
+	Attrs map[string]any
 
 	// Names (possibly as paths) exported from this target
 	Symbols []Symbol
 }
 
-type TargetAction interface{}
+type TargetAction any
 
 type AddTargetAction struct {
 	TargetAction

--- a/language/orion/plugin/target.star.go
+++ b/language/orion/plugin/target.star.go
@@ -111,7 +111,7 @@ func readSymbol(v starlark.Value) (Symbol, error) {
 	return s, nil
 }
 
-func readTargetAttributeValue(v starlark.Value) (interface{}, error) {
+func readTargetAttributeValue(v starlark.Value) (any, error) {
 	// Types that are both starlark.Value and plugin.*
 	switch v := v.(type) {
 	case TargetImport:

--- a/language/orion/starlark/eval.go
+++ b/language/orion/starlark/eval.go
@@ -2,6 +2,7 @@ package starlark
 
 import (
 	"fmt"
+	"maps"
 	"path"
 
 	"github.com/bazelbuild/bazel-gazelle/label"
@@ -80,7 +81,7 @@ func threadPrint(t *starlark.Thread, msg string) {
 	fmt.Printf("%s: %s\n", t.Name, msg)
 }
 
-func Eval(rootDir, starpath string, libs starlark.StringDict, locals map[string]interface{}) (starlark.StringDict, error) {
+func Eval(rootDir, starpath string, libs starlark.StringDict, locals map[string]any) (starlark.StringDict, error) {
 	// Predeclared libs in addition to the go.starlark.net/starlark standard library:
 	// * https://github.com/google/starlark-go/blob/f86470692795f8abcf9f837a3c53cf031c5a3d7e/starlark/library.go#L36-L73
 	// * https://github.com/google/starlark-go/blob/f86470692795f8abcf9f837a3c53cf031c5a3d7e/cmd/starlark/starlark.go#L96-L100
@@ -89,9 +90,7 @@ func Eval(rootDir, starpath string, libs starlark.StringDict, locals map[string]
 		"json": json.Module,
 	}
 
-	for libName, lib := range libs {
-		predeclared[libName] = lib
-	}
+	maps.Copy(predeclared, libs)
 
 	loader := makeLoadOptions(opts, predeclared)
 	loader = createRepoLoader(rootDir, loader)

--- a/language/orion/starlark/eval_test.go
+++ b/language/orion/starlark/eval_test.go
@@ -27,7 +27,7 @@ func run(t *testing.T, code string) (starlark.StringDict, error) {
 		t.Errorf("Temp star close failure: %v", err)
 	}
 
-	return Eval(testDir, testFile, make(map[string]starlark.Value), make(map[string]interface{}))
+	return Eval(testDir, testFile, make(map[string]starlark.Value), make(map[string]any))
 }
 
 func runOk(t *testing.T, code string) starlark.StringDict {

--- a/language/orion/starlark/utils/lib.go
+++ b/language/orion/starlark/utils/lib.go
@@ -2,6 +2,7 @@ package starlark
 
 import (
 	"fmt"
+	"maps"
 
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
@@ -14,9 +15,7 @@ func CreateModule(name string, funcs map[string]ModuleFunction, props map[string
 	for k, v := range funcs {
 		builtins[k] = starlark.NewBuiltin(fmt.Sprintf("%s.%s", name, k), v)
 	}
-	for k, v := range props {
-		builtins[k] = v
-	}
+	maps.Copy(builtins, props)
 
 	return &starlarkstruct.Module{
 		Name:    name,

--- a/language/orion/starlark/utils/util.go
+++ b/language/orion/starlark/utils/util.go
@@ -10,7 +10,7 @@ import (
 var EmptyKwArgs = make([]starlark.Tuple, 0)
 var EmptyStrings = make([]string, 0)
 
-func Write(v interface{}) starlark.Value {
+func Write(v any) starlark.Value {
 	if sv, isSV := v.(starlark.Value); isSV {
 		return sv
 	}
@@ -31,9 +31,9 @@ func Write(v interface{}) starlark.Value {
 		return starlark.Float(v)
 	case []string:
 		return WriteList(v, WriteString)
-	case []interface{}:
+	case []any:
 		return WriteList(v, Write)
-	case map[string]interface{}:
+	case map[string]any:
 		return WriteMap(v, Write)
 	}
 
@@ -119,11 +119,11 @@ func ReadStringTuple(l starlark.Tuple) ([]string, error) {
 	return ReadTuple(l, ReadString)
 }
 
-func Read(v starlark.Value) (interface{}, error) {
+func Read(v starlark.Value) (any, error) {
 	return ReadRecurse(v, Read)
 }
 
-func ReadRecurse(v starlark.Value, read func(v starlark.Value) (interface{}, error)) (interface{}, error) {
+func ReadRecurse(v starlark.Value, read func(v starlark.Value) (any, error)) (any, error) {
 	switch v := v.(type) {
 	case starlark.NoneType:
 		return nil, nil
@@ -151,11 +151,11 @@ func ReadRecurse(v starlark.Value, read func(v starlark.Value) (interface{}, err
 	return nil, fmt.Errorf("failed to read starlark value %T", v)
 }
 
-func readIterable(v starlark.Iterable, len int, read func(v starlark.Value) (interface{}, error)) (interface{}, error) {
+func readIterable(v starlark.Iterable, len int, read func(v starlark.Value) (any, error)) (any, error) {
 	iter := v.Iterate()
 	defer iter.Done()
 
-	a := make([]interface{}, 0, len)
+	a := make([]any, 0, len)
 	var x starlark.Value
 	for iter.Next(&x) {
 		val, err := read(x)
@@ -168,9 +168,9 @@ func readIterable(v starlark.Iterable, len int, read func(v starlark.Value) (int
 	return a, nil
 }
 
-func readIndexable(v starlark.Indexable, read func(v starlark.Value) (interface{}, error)) ([]interface{}, error) {
+func readIndexable(v starlark.Indexable, read func(v starlark.Value) (any, error)) ([]any, error) {
 	len := v.Len()
-	a := make([]interface{}, 0, len)
+	a := make([]any, 0, len)
 	for i := range len {
 		val, err := read(v.Index(i))
 		if err != nil {

--- a/language/orion/starlark/utils/util_test.go
+++ b/language/orion/starlark/utils/util_test.go
@@ -78,7 +78,7 @@ func TestReadWrite(t *testing.T) {
 	})
 
 	t.Run("List => []interface{}", func(t *testing.T) {
-		a := ([]interface{}{int64(1), "hello", true})
+		a := ([]any{int64(1), "hello", true})
 		l := Write(a).(*starlark.List)
 
 		if len(a) != l.Len() {
@@ -127,7 +127,7 @@ func TestReadWrite(t *testing.T) {
 			t.Errorf("Unexpected error: %v", err)
 		}
 
-		a := av.([]interface{})
+		a := av.([]any)
 		if len(a) != l.Len() {
 			t.Errorf("Expected equal length")
 		}

--- a/language/orion/starzelle/plugin.go
+++ b/language/orion/starzelle/plugin.go
@@ -36,7 +36,7 @@ func LoadProxy(host plugin.PluginHost, pluginDir, pluginPath string) error {
 		pluginPath: pluginPath,
 		host:       host,
 	}
-	evalState := make(map[string]interface{})
+	evalState := make(map[string]any)
 	evalState[proxyStateKey] = &state
 
 	libs := starlark.StringDict{

--- a/runner/language/bzl/gazelle.go
+++ b/runner/language/bzl/gazelle.go
@@ -28,6 +28,7 @@ import (
 	"io/ioutil"
 	"log"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -140,7 +141,7 @@ func (*bzlLibraryLang) Embeds(r *rule.Rule, from label.Label) []label.Label { re
 // language.GenerateResult.Imports. Resolve generates a "deps" attribute (or
 // the appropriate language-specific equivalent) for each import according to
 // language-specific rules and heuristics.
-func (*bzlLibraryLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, importsRaw interface{}, from label.Label) {
+func (*bzlLibraryLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, importsRaw any, from label.Label) {
 	imports := importsRaw.([]string)
 
 	r.DelAttr("deps")
@@ -222,7 +223,7 @@ var kinds = map[string]rule.KindInfo{
 // log.Print.
 func (*bzlLibraryLang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
 	var rules []*rule.Rule
-	var imports []interface{}
+	var imports []any
 	for _, f := range append(args.RegularFiles, args.GenFiles...) {
 		if !isBzlSourceFile(f) {
 			continue
@@ -326,12 +327,7 @@ func generateEmpty(args language.GenerateArgs) []*rule.Rule {
 type srcsList []string
 
 func (s srcsList) Contains(m string) bool {
-	for _, e := range s {
-		if e == m {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s, m)
 }
 
 // checkInternalVisibility overrides the given visibility if the package is

--- a/runner/pkg/git/gitignore.go
+++ b/runner/pkg/git/gitignore.go
@@ -15,7 +15,7 @@ import (
 
 type isGitIgnored func(pathParts []string, isDir bool) bool
 
-func processGitignoreFile(rootDir, gitignorePath string, d interface{}) (func(pathParts []string, isDir bool) bool, interface{}) {
+func processGitignoreFile(rootDir, gitignorePath string, d any) (func(pathParts []string, isDir bool) bool, any) {
 	var ignorePatterns []gitignore.Pattern
 	if d != nil {
 		ignorePatterns = d.([]gitignore.Pattern)

--- a/runner/pkg/git/testing/language.go
+++ b/runner/pkg/git/testing/language.go
@@ -28,7 +28,7 @@ func (p *gitLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 	return language.GenerateResult{}
 }
 func (p *gitLang) DoneGeneratingRules() {}
-func (p *gitLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imports interface{}, from label.Label) {
+func (p *gitLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imports any, from label.Label) {
 }
 func (p *gitLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {}
 func (p *gitLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error {

--- a/runner/pkg/ibp/protocol.go
+++ b/runner/pkg/ibp/protocol.go
@@ -84,7 +84,7 @@ type CycleSourcesMessage struct {
 // The versions supported by this host implementation of the protocol.
 var abazelSupportedProtocolVersions = []ProtocolVersion{PROTOCOL_VERSION}
 
-type aspectBazelSocket = socket.Server[interface{}, map[string]any]
+type aspectBazelSocket = socket.Server[any, map[string]any]
 
 type aspectBazelProtocol struct {
 	socket     aspectBazelSocket
@@ -102,7 +102,7 @@ func NewServer() IncrementalBazel {
 	socketPath := path.Join(os.TempDir(), fmt.Sprintf("aspect-watch-%v-socket", os.Getpid()))
 	return &aspectBazelProtocol{
 		socketPath: socketPath,
-		socket:     socket.NewJsonServer[interface{}, map[string]interface{}](),
+		socket:     socket.NewJsonServer[any, map[string]any](),
 
 		connectedCh: make(chan ProtocolVersion, 1),
 	}

--- a/runner/pkg/socket/json.go
+++ b/runner/pkg/socket/json.go
@@ -7,15 +7,15 @@ import (
 	"net"
 )
 
-type jsonSocket[S, R interface{}] struct {
+type jsonSocket[S, R any] struct {
 	conn  net.Conn
 	write *json.Encoder
 	read  *json.Decoder
 }
-type jsonClientSocket[S, R interface{}] struct {
+type jsonClientSocket[S, R any] struct {
 	jsonSocket[S, R]
 }
-type jsonServerSocket[S, R interface{}] struct {
+type jsonServerSocket[S, R any] struct {
 	jsonSocket[S, R]
 
 	serv net.Listener
@@ -24,7 +24,7 @@ type jsonServerSocket[S, R interface{}] struct {
 var _ Socket[any, any] = (*jsonSocket[any, any])(nil)
 var _ Server[any, any] = (*jsonServerSocket[any, any])(nil)
 
-func ConnectJsonSocket[S, R interface{}](socketPath string) (Socket[S, R], error) {
+func ConnectJsonSocket[S, R any](socketPath string) (Socket[S, R], error) {
 	s := &jsonClientSocket[S, R]{}
 	if err := s.connect(socketPath); err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func ConnectJsonSocket[S, R interface{}](socketPath string) (Socket[S, R], error
 	return s, nil
 }
 
-func NewJsonServer[S, R interface{}]() Server[S, R] {
+func NewJsonServer[S, R any]() Server[S, R] {
 	return &jsonServerSocket[S, R]{}
 }
 

--- a/runner/pkg/socket/socket.go
+++ b/runner/pkg/socket/socket.go
@@ -1,12 +1,12 @@
 package socket
 
-type Socket[S, R interface{}] interface {
+type Socket[S, R any] interface {
 	Send(cmd S) error
 	Recv() (R, error)
 	Close() error
 }
 
-type Server[S, R interface{}] interface {
+type Server[S, R any] interface {
 	Socket[S, R]
 	Serve(path string) error
 	Accept() error

--- a/runner/pkg/watchman/cache.go
+++ b/runner/pkg/watchman/cache.go
@@ -89,7 +89,7 @@ func closeWatchmanCache(c *watchmanCache) {
 func (c *watchmanCache) populateWalkCache(cfg *config.Config) {
 	// If a walk cache was provided also provide the loader to copy the cached entries
 	// into any fresh walk cache. This must be invoked from a patched gazelle walk.
-	cfg.Exts["aspect:walkCache:load"] = func(m interface{}) {
+	cfg.Exts["aspect:walkCache:load"] = func(m any) {
 		cc := 0
 
 		newWalkCache := m.(*sync.Map)
@@ -196,9 +196,9 @@ func (c *watchmanCache) write() {
 	m := make(map[string]map[string]any)
 
 	// Convert the sync.Map[sync.Map] to a regular map for serialization.
-	c.new.Range(func(key, value interface{}) bool {
+	c.new.Range(func(key, value any) bool {
 		mValue := make(map[string]any)
-		value.(*sync.Map).Range(func(k, v interface{}) bool {
+		value.(*sync.Map).Range(func(k, v any) bool {
 			mValue[k.(string)] = v
 			return true
 		})

--- a/runner/progress/progress.go
+++ b/runner/progress/progress.go
@@ -68,7 +68,7 @@ func (p *progressLang) run(ctx context.Context) {
 func writeStatus(s *progressStatus) {
 	// NOTE(windows): syscall.Stdout is a `Handle` on windows and `int` on other platforms,
 	// while `term.GetSize` only accepts the `int` type.
-	var sysStdout interface{} = syscall.Stdout
+	var sysStdout any = syscall.Stdout
 
 	width, _, err := term.GetSize(sysStdout.(int))
 	if err != nil {
@@ -130,7 +130,7 @@ func (p *progressLang) DoneGeneratingRules() {
 }
 
 // 5. Indexing done, starting resolving
-func (p *progressLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imports interface{}, from label.Label) {
+func (p *progressLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imports any, from label.Label) {
 	p.send(progressPhaseResolve, "dependencies")
 }
 


### PR DESCRIPTION
Use modern Go idioms: interface{} -> any, maps.Copy, slices.Contains, strings.Cut, and empty interface type simplifications.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
