### PR TITLE
feat: add js_rule_kind directive for per-group rule kind override

### DIFF
--- a/language/js/config.go
+++ b/language/js/config.go
@@ -60,6 +60,9 @@ const (
 	Directive_TestFiles = "js_test_files"
 	// The directive controlling whether asset collection is enabled for import types.
 	Directive_Assets = "js_assets"
+	// Directive_RuleKind overrides the generated rule kind for a specific target group.
+	// Syntax: # gazelle:js_rule_kind <group_name> <kind_name>
+	Directive_RuleKind = "js_rule_kind"
 
 	// TODO(deprecated): remove - replaced with js_files [group]
 	Directive_CustomTargetFiles = "js_custom_files"
@@ -111,6 +114,10 @@ type TargetGroup struct {
 
 	// If the targets are always testonly
 	testonly bool
+
+	// Per-group rule kind override. Empty string means use the default
+	// (ts_project or js_library based on source content).
+	ruleKind string
 }
 
 var DefaultSourceGlobs = []*TargetGroup{
@@ -235,6 +242,7 @@ func (g *TargetGroup) newChild() *TargetGroup {
 		defaultSources: sources,
 		testonly:       g.testonly,
 		visibility:     g.visibility,
+		ruleKind:       g.ruleKind,
 	}
 }
 
@@ -284,6 +292,25 @@ func (c *JsGazelleConfig) SetVisibility(groupName string, visLabels []string) er
 		target.visibility = append(target.visibility, l)
 	}
 
+	return nil
+}
+
+func (c *JsGazelleConfig) SetRuleKind(groupName, kindName string) error {
+	target := c.GetSourceTarget(groupName)
+	if target == nil {
+		return fmt.Errorf("Target group %q not found in %q", groupName, c.rel)
+	}
+
+	if kindName != "" {
+		switch kindName {
+		case TsProjectKind, JsLibraryKind, JsTestKind:
+			// valid source target kinds
+		default:
+			return fmt.Errorf("unknown rule kind %q; must be one of: ts_project, js_library, js_test. Use map_kind to remap to a custom rule", kindName)
+		}
+	}
+
+	target.ruleKind = kindName
 	return nil
 }
 

--- a/language/js/config.go
+++ b/language/js/config.go
@@ -61,7 +61,7 @@ const (
 	// The directive controlling whether asset collection is enabled for import types.
 	Directive_Assets = "js_assets"
 	// Directive_RuleKind overrides the generated rule kind for a specific target group.
-	// Syntax: # gazelle:js_rule_kind <group_name> <kind_name>
+	// Syntax: # gazelle:js_rule_kind <group_name> [kind_name]
 	Directive_RuleKind = "js_rule_kind"
 
 	// TODO(deprecated): remove - replaced with js_files [group]

--- a/language/js/configure.go
+++ b/language/js/configure.go
@@ -262,7 +262,11 @@ func (ts *typeScriptLang) readDirectives(c *config.Config, rel string, f *rule.F
 			parts := strings.Fields(value)
 			if len(parts) == 1 {
 				// Reset to default (auto-detect from source content)
-				config.SetRuleKind(parts[0], "")
+				err := config.SetRuleKind(parts[0], "")
+				if err != nil {
+					common.MisconfiguredErrorf(c, "Invalid %s: %v", Directive_RuleKind, err)
+					return
+				}
 			} else if len(parts) == 2 {
 				err := config.SetRuleKind(parts[0], parts[1])
 				if err != nil {

--- a/language/js/configure.go
+++ b/language/js/configure.go
@@ -56,6 +56,7 @@ func (ts *typeScriptLang) KnownDirectives() []string {
 		Directive_LibraryFiles,
 		Directive_TestFiles,
 		Directive_Assets,
+		Directive_RuleKind,
 
 		// TODO(deprecated): remove
 		Directive_CustomTargetFiles,
@@ -256,6 +257,23 @@ func (ts *typeScriptLang) readDirectives(c *config.Config, rel string, f *rule.F
 
 			// Overwrite any inherited configuration for asset collection.
 			config.SetCollectAssetsFrom(assetKinds...)
+
+		case Directive_RuleKind:
+			parts := strings.Fields(value)
+			if len(parts) == 1 {
+				// Reset to default (auto-detect from source content)
+				config.SetRuleKind(parts[0], "")
+			} else if len(parts) == 2 {
+				err := config.SetRuleKind(parts[0], parts[1])
+				if err != nil {
+					common.MisconfiguredErrorf(c, "Invalid %s: %v", Directive_RuleKind, err)
+					return
+				}
+			} else {
+				common.MisconfiguredErrorf(c, "invalid value for directive %q: %s: expected 'group_name [kind_name]'",
+					Directive_RuleKind, d.Value)
+				return
+			}
 
 		// TODO: remove, deprecated
 		case Directive_CustomTargetFiles:

--- a/language/js/generate.go
+++ b/language/js/generate.go
@@ -484,7 +484,11 @@ func hasTranspiledSources(sourceFiles *treeset.Set[string]) bool {
 
 func (ts *typeScriptLang) addProjectRule(cfg *JsGazelleConfig, tsconfigRel string, tsconfig *typescript.TsConfig, args language.GenerateArgs, group *TargetGroup, targetName string, sourceFiles, genFiles, dataFiles []string, result *language.GenerateResult) (*rule.Rule, error) {
 	// Check for name-collisions with the rule being generated.
-	colError := ruleUtils.CheckCollisionErrors(targetName, TsProjectKind, sourceRuleKinds, args)
+	expectedKind := TsProjectKind
+	if group.ruleKind != "" {
+		expectedKind = group.ruleKind
+	}
+	colError := ruleUtils.CheckCollisionErrors(targetName, expectedKind, sourceRuleKinds, args)
 	if colError != nil {
 		return nil, fmt.Errorf("%v "+
 			"Use the '# aspect:%s' directive to change the naming convention.\n\n"+
@@ -569,9 +573,14 @@ func (ts *typeScriptLang) addProjectRule(cfg *JsGazelleConfig, tsconfigRel strin
 	// A rule of the same name might already exist
 	existing := ruleUtils.GetFileRuleByName(args, targetName)
 
-	ruleKind := TsProjectKind
+	defaultKind := TsProjectKind
 	if !hasTranspiledSources(info.sources) {
-		ruleKind = JsLibraryKind
+		defaultKind = JsLibraryKind
+	}
+
+	ruleKind := defaultKind
+	if group.ruleKind != "" {
+		ruleKind = group.ruleKind
 	}
 	sourceRule := rule.NewRule(ruleKind, targetName)
 
@@ -604,7 +613,7 @@ func (ts *typeScriptLang) addProjectRule(cfg *JsGazelleConfig, tsconfigRel strin
 		sourceRule.DelAttr("assets")
 	}
 
-	if group.testonly {
+	if group.testonly && ruleKind != JsTestKind {
 		sourceRule.SetAttr("testonly", true)
 	}
 

--- a/language/js/kinds.go
+++ b/language/js/kinds.go
@@ -11,6 +11,7 @@ const (
 	TsProjectKind         = "ts_project"
 	TsProtoLibraryKind    = "ts_proto_library"
 	JsLibraryKind         = "js_library"
+	JsTestKind            = "js_test"
 	JsBinaryKind          = "js_binary"
 	JsRunBinaryKind       = "js_run_binary"
 	TsConfigKind          = "ts_config"
@@ -23,7 +24,7 @@ const (
 	NpmRepositoryName     = "npm"
 )
 
-var sourceRuleKinds = treeset.NewWith(strings.Compare, TsProjectKind, JsLibraryKind, TsProtoLibraryKind)
+var sourceRuleKinds = treeset.NewWith(strings.Compare, TsProjectKind, JsLibraryKind, JsTestKind, TsProtoLibraryKind)
 
 // Kinds returns a map that maps rule names (kinds) and information on how to
 // match and merge attributes that may be found in rules of those kinds.
@@ -66,6 +67,19 @@ var tsKinds = map[string]rule.KindInfo{
 		},
 	},
 	JsLibraryKind: {
+		MatchAny: false,
+		NonEmptyAttrs: map[string]bool{
+			"srcs": true,
+		},
+		SubstituteAttrs: map[string]bool{},
+		MergeableAttrs: map[string]bool{
+			"srcs": true,
+		},
+		ResolveAttrs: map[string]bool{
+			"deps": true,
+		},
+	},
+	JsTestKind: {
 		MatchAny: false,
 		NonEmptyAttrs: map[string]bool{
 			"srcs": true,
@@ -183,7 +197,7 @@ func (h *typeScriptLang) ApparentLoads(moduleToApparentName func(string) string)
 		{
 			Name: "@" + jsModName + "//js:defs.bzl",
 			Symbols: []string{
-				JsLibraryKind, JsBinaryKind, JsRunBinaryKind,
+				JsLibraryKind, JsTestKind, JsBinaryKind, JsRunBinaryKind,
 			},
 		},
 

--- a/language/js/resolve.go
+++ b/language/js/resolve.go
@@ -48,9 +48,7 @@ func (ts *typeScriptLang) Imports(c *config.Config, r *rule.Rule, f *rule.File) 
 		return ts.protoLibraryImports(r, f)
 	case TsConfigKind:
 		return ts.tsconfigImports(r, f)
-	case TsProjectKind:
-		fallthrough
-	case JsLibraryKind:
+	case TsProjectKind, JsLibraryKind, JsTestKind:
 		return ts.sourceFileImports(c, r, f)
 	}
 	return nil
@@ -296,7 +294,7 @@ func (ts *typeScriptLang) Resolve(
 
 	// TsProject imports are resolved as deps
 	switch r.Kind() {
-	case TsProjectKind, JsLibraryKind, TsConfigKind, TsProtoLibraryKind:
+	case TsProjectKind, JsLibraryKind, JsTestKind, TsConfigKind, TsProtoLibraryKind:
 		deps := common.NewLabelSet(from)
 
 		// Support this target representing a project or a package

--- a/language/js/tests/rule_kind_custom_group/BUILD.in
+++ b/language/js/tests/rule_kind_custom_group/BUILD.in
@@ -1,0 +1,3 @@
+# gazelle:js_test_files e2e *.e2e.ts
+# gazelle:js_rule_kind e2e js_test
+# gazelle:map_kind js_test jest_test //:defs.bzl

--- a/language/js/tests/rule_kind_custom_group/BUILD.out
+++ b/language/js/tests/rule_kind_custom_group/BUILD.out
@@ -1,0 +1,24 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("//:defs.bzl", "jest_test")
+
+# gazelle:js_test_files e2e *.e2e.ts
+# gazelle:js_rule_kind e2e js_test
+# gazelle:map_kind js_test jest_test //:defs.bzl
+
+ts_project(
+    name = "rule_kind_custom_group",
+    srcs = ["main.ts"],
+)
+
+ts_project(
+    name = "rule_kind_custom_group_tests",
+    testonly = True,
+    srcs = ["main.spec.ts"],
+    deps = [":rule_kind_custom_group"],
+)
+
+jest_test(
+    name = "e2e",
+    srcs = ["main.e2e.ts"],
+    deps = [":rule_kind_custom_group"],
+)

--- a/language/js/tests/rule_kind_custom_group/WORKSPACE
+++ b/language/js/tests/rule_kind_custom_group/WORKSPACE
@@ -1,0 +1,2 @@
+# This is a Bazel workspace for the Gazelle test data.
+workspace(name = "rule_kind_custom_group")

--- a/language/js/tests/rule_kind_custom_group/main.e2e.ts
+++ b/language/js/tests/rule_kind_custom_group/main.e2e.ts
@@ -1,0 +1,3 @@
+import { A } from './main';
+
+console.log('e2e', A);

--- a/language/js/tests/rule_kind_custom_group/main.spec.ts
+++ b/language/js/tests/rule_kind_custom_group/main.spec.ts
@@ -1,0 +1,3 @@
+import { A } from './main';
+
+console.log(A);

--- a/language/js/tests/rule_kind_custom_group/main.ts
+++ b/language/js/tests/rule_kind_custom_group/main.ts
@@ -1,0 +1,1 @@
+export const A = 'hello';

--- a/language/js/tests/rule_kind_override/BUILD.in
+++ b/language/js/tests/rule_kind_override/BUILD.in
@@ -1,0 +1,1 @@
+# gazelle:js_rule_kind {dirname}_tests js_test

--- a/language/js/tests/rule_kind_override/BUILD.out
+++ b/language/js/tests/rule_kind_override/BUILD.out
@@ -1,0 +1,15 @@
+load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+# gazelle:js_rule_kind {dirname}_tests js_test
+
+ts_project(
+    name = "rule_kind_override",
+    srcs = ["main.ts"],
+)
+
+js_test(
+    name = "rule_kind_override_tests",
+    srcs = ["main.spec.ts"],
+    deps = [":rule_kind_override"],
+)

--- a/language/js/tests/rule_kind_override/WORKSPACE
+++ b/language/js/tests/rule_kind_override/WORKSPACE
@@ -1,0 +1,2 @@
+# This is a Bazel workspace for the Gazelle test data.
+workspace(name = "rule_kind_override")

--- a/language/js/tests/rule_kind_override/main.spec.ts
+++ b/language/js/tests/rule_kind_override/main.spec.ts
@@ -1,0 +1,3 @@
+import { A } from './main';
+
+console.log(A);

--- a/language/js/tests/rule_kind_override/main.ts
+++ b/language/js/tests/rule_kind_override/main.ts
@@ -1,0 +1,1 @@
+export const A = 'hello';

--- a/language/js/tests/rule_kind_override/sub/BUILD.out
+++ b/language/js/tests/rule_kind_override/sub/BUILD.out
@@ -1,0 +1,13 @@
+load("@aspect_rules_js//js:defs.bzl", "js_test")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+ts_project(
+    name = "sub",
+    srcs = ["lib.ts"],
+)
+
+js_test(
+    name = "sub_tests",
+    srcs = ["lib.spec.ts"],
+    deps = [":sub"],
+)

--- a/language/js/tests/rule_kind_override/sub/lib.spec.ts
+++ b/language/js/tests/rule_kind_override/sub/lib.spec.ts
@@ -1,0 +1,3 @@
+import { B } from './lib';
+
+console.log(B);

--- a/language/js/tests/rule_kind_override/sub/lib.ts
+++ b/language/js/tests/rule_kind_override/sub/lib.ts
@@ -1,0 +1,1 @@
+export const B = 'world';


### PR DESCRIPTION
## Per-group rule kind override via `js_rule_kind` directive

### The gap

The JS/TS gazelle extension generates `ts_project(testonly=True)` for test files. This compiles tests but does **not** produce a `bazel test`-able target. There is no way to get an executable test rule like `jest_test` or `vitest_test` from gazelle, analogous to how the Go extension generates `go_test` rather than just `go_library`.

The existing `map_kind` directive cannot solve this because it remaps **all** rules of a given kind. Writing `# gazelle:map_kind ts_project jest_test //:defs.bzl` would remap both library and test targets, which is not the intent.

The root cause is structural: the Go extension distinguishes `go_library` from `go_test` as separate static kinds that can be independently remapped. The JS extension uses `ts_project` for both, distinguished only by `testonly = True`.

### The fix

Register `js_test` (from `@aspect_rules_js//js:defs.bzl`) as a static source rule kind, the test-target counterpart to `ts_project`/`js_library`. A new `js_rule_kind` directive selects the rule kind per target group. Since `js_test` is statically registered in `Kinds()` and `ApparentLoads()`, the gazelle framework's resolver, merger, and load-statement generation all work without workarounds.

Users who want a specific test runner combine this with the existing `map_kind`:

```
# gazelle:js_rule_kind {dirname}_tests js_test
# gazelle:map_kind js_test jest_test @aspect_rules_jest//jest:defs.bzl
```

This is the same two-layer pattern the Go extension uses: gazelle emits a canonical kind (`go_test`), users remap it to their preferred macro.

**Backwards compatible**: default behavior is unchanged. No directive means `ts_project(testonly=True)` as before.

The directive inherits to subdirectories and can be reset in a child package with `# gazelle:js_rule_kind {dirname}_tests` (group name only, no kind).

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no (README table needs a row for `js_rule_kind`)
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

>Added `js_rule_kind` directive to override the generated rule kind for a target group. Use `# gazelle:js_rule_kind {dirname}_tests js_test` to generate `js_test` instead of `ts_project(testonly=True)` for test targets. Combine with `map_kind` to remap to `jest_test`, `vitest_test`, or other test runners.

### Test plan

- Covered by existing test cases (120 pre-existing tests pass, confirming no regressions)
- New test cases added:
  - `rule_kind_override` -  `js_rule_kind` on default test group with subdirectory inheritance
  - `rule_kind_custom_group` - `js_rule_kind` on a custom group with `map_kind` remapping to `jest_test`
