### PR TITLE
feat: Add HCL tree-sitter parser

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -107,6 +107,20 @@ visibility = ["//visibility:public"],
 )
 
 http_archive(
+    name = "tree-sitter-hcl",
+    build_file_content = """
+filegroup(
+    name = "srcs",
+    srcs = glob(["src/**/*.c", "src/**/*.cc", "src/**/*.h"]),
+    visibility = ["//visibility:public"],
+)
+""",
+    sha256 = "6d58a1c647d04fcbe560bf92b7a702e938cd6f83802e29052fb2e28e7557efee",
+    strip_prefix = "tree-sitter-hcl-1.0.0",
+    urls = ["https://github.com/tree-sitter-grammars/tree-sitter-hcl/archive/v1.0.0.tar.gz"],
+)
+
+http_archive(
     name = "tree-sitter-ruby",
     build_file_content = """
 filegroup(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,14 @@ module(
 bazel_dep(name = "rules_go", version = "0.60.0")
 bazel_dep(name = "gazelle", version = "0.48.0")  # must match go.mod
 
+# Needed so that //common/treesitter/grammars/hcl can pull libc++/libc++abi/libunwind
+# static archives into cgo's link inputs when building with the LLVM toolchain (see
+# common/treesitter/grammars/hcl/BUILD.bazel). The cdeps reference is gated on a
+# `--define=link_llvm_libcxx=true` config_setting, so non-LLVM builds don't link
+# against any of these targets — but the labels still have to resolve at loading
+# time, which is why this can't be a dev_dependency.
+bazel_dep(name = "llvm", version = "0.7.0")
+
 # Go modules
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//common:go.mod")
@@ -109,9 +117,11 @@ visibility = ["//visibility:public"],
 http_archive(
     name = "tree-sitter-hcl",
     build_file_content = """
-filegroup(
-    name = "srcs",
-    srcs = glob(["src/**/*.c", "src/**/*.cc", "src/**/*.h"]),
+cc_library(
+    name = "tree-sitter-hcl",
+    srcs = glob(["src/**/*.c", "src/**/*.cc"]),
+    hdrs = glob(["src/**/*.h"]),
+    includes = ["src"],
     visibility = ["//visibility:public"],
 )
 """,

--- a/common/treesitter/grammars/hcl/BUILD.bazel
+++ b/common/treesitter/grammars/hcl/BUILD.bazel
@@ -1,13 +1,61 @@
 load("@rules_go//go:def.bzl", "go_library")
 
+# tree-sitter-hcl's external scanner is C++ (scanner.cc) and pulls in libc++
+# (operator new, std::string, exception ABI, etc.). rules_go's cgo link path
+# bypasses the cc_toolchain.static_runtime_lib injection that normally adds
+# libc++/libc++abi/libunwind for C++ cc_libraries (see go/private/actions/link.bzl
+# and go/tools/builders/cgo2.go). With the LLVM toolchain (`runner/.bazelrc`),
+# this means linking the cli or any go_binary that transitively depends on this
+# library produces undefined references to operator new, __cxa_throw, etc.
+#
+# Workaround: when `--define=link_llvm_libcxx=true` is set (currently done in
+# `runner/.bazelrc`), pull the real libc++/libc++abi/libunwind static archives
+# from the LLVM module into cgo's link inputs as cdeps. The .a paths flow
+# through cgo.bzl's `_cc_libs_and_flags` into clinkopts and end up on the cgo
+# link line.
+#
+# When the define is not set (e.g. when building aspect-gazelle on its own with
+# the system gcc toolchain), the select picks the empty list and the build
+# falls back to libstdc++ resolution via DT_NEEDED on the tree-sitter-hcl .so,
+# which already works.
+#
+# The @llvm//runtimes/libcxx:libcxx.static targets are `cc_static_library`
+# (terminal) rules that produce a single .a file but do NOT expose CcInfo, so
+# cgo.bzl's `_cc_libs_and_flags` can't consume them directly. Wrap each one in
+# a cc_import to re-expose the static archive as a proper CcInfo target.
+config_setting(
+    name = "link_llvm_libcxx",
+    define_values = {"link_llvm_libcxx": "true"},
+    visibility = ["//visibility:private"],
+)
+
+cc_import(
+    name = "libcxx_imported",
+    static_library = "@llvm//runtimes/libcxx:libcxx.static",
+)
+
+cc_import(
+    name = "libcxxabi_imported",
+    static_library = "@llvm//runtimes/libcxx:libcxxabi.static",
+)
+
+cc_import(
+    name = "libunwind_imported",
+    static_library = "@llvm//runtimes/libunwind:libunwind.static",
+)
+
 go_library(
     name = "hcl",
-    srcs = [
-        "binding.go",
-        "@tree-sitter-hcl//:srcs",  #keep
-    ],
+    srcs = ["binding.go"],
+    cdeps = ["@tree-sitter-hcl"] + select({
+        ":link_llvm_libcxx": [
+            ":libcxx_imported",
+            ":libcxxabi_imported",
+            ":libunwind_imported",
+        ],
+        "//conditions:default": [],
+    }),  #keep
     cgo = True,
-    copts = ["-Iexternal/*tree-sitter-hcl"],  #keep
     importpath = "github.com/aspect-build/aspect-gazelle/common/treesitter/grammars/hcl",
     visibility = ["//visibility:public"],
     deps = ["//common/treesitter"],

--- a/common/treesitter/grammars/hcl/BUILD.bazel
+++ b/common/treesitter/grammars/hcl/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "hcl",
+    srcs = [
+        "binding.go",
+        "@tree-sitter-hcl//:srcs",  #keep
+    ],
+    cgo = True,
+    copts = ["-Iexternal/*tree-sitter-hcl"],  #keep
+    importpath = "github.com/aspect-build/aspect-gazelle/common/treesitter/grammars/hcl",
+    visibility = ["//visibility:public"],
+    deps = ["//common/treesitter"],
+)

--- a/common/treesitter/grammars/hcl/binding.go
+++ b/common/treesitter/grammars/hcl/binding.go
@@ -1,0 +1,17 @@
+package hcl
+
+//#include "tree_sitter/parser.h"
+//TSLanguage *tree_sitter_hcl();
+import "C"
+import (
+	"unsafe"
+
+	"github.com/aspect-build/aspect-gazelle/common/treesitter"
+)
+
+func NewLanguage() treesitter.Language {
+	return treesitter.NewLanguage(
+		treesitter.HCL,
+		unsafe.Pointer(C.tree_sitter_hcl()),
+	)
+}

--- a/common/treesitter/parser.go
+++ b/common/treesitter/parser.go
@@ -54,6 +54,7 @@ const (
 	Go                          = "go"
 	Rust                        = "rust"
 	Ruby                        = "ruby"
+	HCL                         = "hcl"
 )
 
 type Language any
@@ -146,6 +147,13 @@ var extLanguages = map[string]LanguageGrammar{
 	"jav":  Java,
 	"jsh":  Java,
 	"json": JSON,
+
+	"hcl":      HCL,
+	"nomad":    HCL,
+	"tf":       HCL,
+	"tfvars":   HCL,
+	"tofu":     HCL,
+	"workflow": HCL,
 
 	"rb":       Ruby,
 	"rake":     Ruby,

--- a/language/orion/queries/BUILD.bazel
+++ b/language/orion/queries/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "@aspect_gazelle//common/logger",
         "@aspect_gazelle//common/treesitter",
         "@aspect_gazelle//common/treesitter/grammars/golang",
+        "@aspect_gazelle//common/treesitter/grammars/hcl",
         "@aspect_gazelle//common/treesitter/grammars/java",
         "@aspect_gazelle//common/treesitter/grammars/json",
         "@aspect_gazelle//common/treesitter/grammars/kotlin",

--- a/language/orion/queries/ast.go
+++ b/language/orion/queries/ast.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aspect-build/aspect-gazelle/common/treesitter"
 	treeutils "github.com/aspect-build/aspect-gazelle/common/treesitter"
 	"github.com/aspect-build/aspect-gazelle/common/treesitter/grammars/golang"
+	"github.com/aspect-build/aspect-gazelle/common/treesitter/grammars/hcl"
 	"github.com/aspect-build/aspect-gazelle/common/treesitter/grammars/java"
 	"github.com/aspect-build/aspect-gazelle/common/treesitter/grammars/json"
 	"github.com/aspect-build/aspect-gazelle/common/treesitter/grammars/kotlin"
@@ -66,6 +67,8 @@ func toTreeLanguage(fileName string, queries plugin.NamedQueries) treesitter.Lan
 	switch lang {
 	case treesitter.Go:
 		return golang.NewLanguage()
+	case treesitter.HCL:
+		return hcl.NewLanguage()
 	case treesitter.Java:
 		return java.NewLanguage()
 	case treesitter.JSON:

--- a/language/orion/tests/starzelle/query-hcl/BUILD.out
+++ b/language/orion/tests/starzelle/query-hcl/BUILD.out
@@ -1,0 +1,10 @@
+load("@deps-test//my:rules.bzl", "hcl_library")
+
+hcl_library(
+    name = "main_lib",
+    srcs = ["main.tf"],
+    blocks = [
+        "variable",
+        "resource",
+    ],
+)

--- a/language/orion/tests/starzelle/query-hcl/WORKSPACE
+++ b/language/orion/tests/starzelle/query-hcl/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "query-hcl")

--- a/language/orion/tests/starzelle/query-hcl/hcl.axl
+++ b/language/orion/tests/starzelle/query-hcl/hcl.axl
@@ -1,0 +1,35 @@
+aspect.gazelle_rule_kind("hcl_library", {
+    "From": "@deps-test//my:rules.bzl",
+    "MergeableAttrs": ["srcs"],
+})
+
+def declare(ctx):
+    for file in ctx.sources:
+        blocks = [m.captures["block_type"] for m in file.query_results["blocks"]]
+        ctx.targets.add(
+            name = file.path[:file.path.rindex(".")] + "_lib",
+            kind = "hcl_library",
+            attrs = {
+                "srcs": [file.path],
+                "blocks": blocks,
+            },
+        )
+
+aspect.orion_extension(
+    id = "hcl-test",
+    prepare = lambda _: aspect.PrepareResult(
+        sources = aspect.SourceExtensions(".tf"),
+        queries = {
+            "blocks": aspect.AstQuery(
+                grammar = "hcl",
+                filter = "*.tf",
+                query = """
+                    (block
+                        (identifier) @block_type
+                    )
+                """,
+            ),
+        },
+    ),
+    declare = declare,
+)

--- a/language/orion/tests/starzelle/query-hcl/main.tf
+++ b/language/orion/tests/starzelle/query-hcl/main.tf
@@ -1,0 +1,9 @@
+variable "name" {
+  type    = string
+  default = "world"
+}
+
+resource "local_file" "greeting" {
+  content  = "Hello, ${var.name}!"
+  filename = "/tmp/greeting.txt"
+}

--- a/runner/.bazelrc
+++ b/runner/.bazelrc
@@ -18,3 +18,12 @@ common --linkopt=-no-pie
 # Required by llvm bzlmod
 common --experimental_cc_static_library
 common --experimental_platform_in_output_dir
+
+# Pull libc++/libc++abi/libunwind static archives into cgo's link inputs for
+# go_libraries with C++ cdeps (currently //common/treesitter/grammars/hcl). The
+# LLVM toolchain passes -nostdlib++ and provides libc++ as direct file inputs
+# via cc_toolchain.static_runtime_lib, which rules_go's cgo link path doesn't
+# consume — without this define those go_binaries fail to link with undefined
+# references to operator new, __cxa_throw, etc. See
+# common/treesitter/grammars/hcl/BUILD.bazel for details.
+common --define=link_llvm_libcxx=true


### PR DESCRIPTION
This enables writing Starzelle plugins that read HCL files, including Terraform / OpenTofu. We had to use v1.0.0 of tree-sitter-hcl because the newer versions use ABI 15, which tree-sitter-go does not support.

lacking a good canonical TF ruleset, this just adds a minimal test case for the parser and leaves it up to users to define their own plugins.

Part of aspect-build/rules_lint#325.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below:

Added support for writing Starzelle plugins that parse HCL syntax.

### Test plan

- New test cases added