### PR TITLE
refactor: upgrade treesitter rust grammar to official tree-sitter-rust v0.23

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,6 +33,19 @@ filegroup(
 )
 
 http_archive(
+    name = "tree-sitter-rust",
+    build_file_content = """
+filegroup(
+    name = "srcs",
+    srcs = glob(["src/**/*.c", "src/**/*.h"]),
+    visibility = ["//visibility:public"],
+)
+""",
+    sha256 = "5bad78dfbad2e7cd6781db726b32fc12a519f89ec0fb5da77d9611f674f45b46",
+    urls = ["https://github.com/tree-sitter/tree-sitter-rust/releases/download/v0.23.3/tree-sitter-rust.tar.gz"],
+)
+
+http_archive(
     name = "tree-sitter-java",
     build_file_content = """
 filegroup(

--- a/common/treesitter/grammars/rust/BUILD.bazel
+++ b/common/treesitter/grammars/rust/BUILD.bazel
@@ -2,11 +2,13 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "rust",
-    srcs = ["binding.go"],
+    srcs = [
+        "binding.go",
+        "@tree-sitter-rust//:srcs",  #keep
+    ],
+    cgo = True,
+    copts = ["-Iexternal/*tree-sitter-rust"],  #keep
     importpath = "github.com/aspect-build/aspect-gazelle/common/treesitter/grammars/rust",
     visibility = ["//visibility:public"],
-    deps = [
-        "//common/treesitter",
-        "@com_github_smacker_go_tree_sitter//rust",
-    ],
+    deps = ["//common/treesitter"],
 )

--- a/common/treesitter/grammars/rust/binding.go
+++ b/common/treesitter/grammars/rust/binding.go
@@ -1,14 +1,16 @@
 package rust
 
+//#include "tree_sitter/parser.h"
+//TSLanguage *tree_sitter_rust();
+import "C"
 import (
-	"github.com/aspect-build/aspect-gazelle/common/treesitter"
+	"unsafe"
 
-	// TODO: replace with direct use of https://github.com/tree-sitter/tree-sitter-rust
-	"github.com/smacker/go-tree-sitter/rust"
+	"github.com/aspect-build/aspect-gazelle/common/treesitter"
 )
 
 func NewLanguage() treesitter.Language {
-	return treesitter.NewLanguageFromSitter(
+	return treesitter.NewLanguage(
 		treesitter.Rust,
-		rust.GetLanguage())
+		unsafe.Pointer(C.tree_sitter_rust()))
 }


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
