### PR TITLE
chore: ensure prebuilt patching of go-tree-sitter is dev_dependency=True

### DIFF
--- a/prebuilt/MODULE.bazel
+++ b/prebuilt/MODULE.bazel
@@ -21,37 +21,11 @@ use_repo(
 
 register_toolchains("//toolchain:all")
 
-go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+# Dev only
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps", dev_dependency = True)
 go_deps.module_override(
     patch_strip = 1,
     patches = ["@aspect_gazelle//common/patches:go-tree-sitter-abi15.patch"],
     path = "github.com/smacker/go-tree-sitter",
-)
-
-# Dev only
-
-bazel_dep(name = "aspect_gazelle_runner", dev_dependency = True)
-local_path_override(
-    module_name = "aspect_gazelle_runner",
-    path = "../runner",
-)
-
-local_path_override(
-    module_name = "aspect_gazelle",
-    path = "..",
-)
-
-local_path_override(
-    module_name = "aspect_gazelle_js",
-    path = "../language/js",
-)
-
-local_path_override(
-    module_name = "aspect_gazelle_kotlin",
-    path = "../language/kotlin",
-)
-
-local_path_override(
-    module_name = "aspect_gazelle_orion",
-    path = "../language/orion",
 )


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
