### PR TITLE
fix: honour ORION_EXTENSIONS without requiring ENABLE_LANGUAGES

### DIFF
--- a/runner/bin/gazelle/languages.go
+++ b/runner/bin/gazelle/languages.go
@@ -36,15 +36,16 @@ func init() {
 // resolveLanguages applies ENABLE_LANGUAGES and ORION_EXTENSIONS[_DIR] to the
 // default list. Pure — env lookups live in init().
 func resolveLanguages(defaults []string, enableLangs, orionExt, orionExtDir string) []string {
+	var result []string
 	if enableLangs == "" {
-		return defaults
+		result = defaults
+	} else {
+		result = strings.Split(enableLangs, ",")
 	}
-
-	result := strings.Split(enableLangs, ",")
 
 	// Automatically include orion if extensions are specified
 	if (orionExt != "" || orionExtDir != "") && !slices.Contains(result, runner.Orion) {
-		result = append(result, runner.Orion)
+		result = append(slices.Clone(result), runner.Orion)
 	}
 
 	return result

--- a/runner/bin/gazelle/languages_test.go
+++ b/runner/bin/gazelle/languages_test.go
@@ -39,20 +39,21 @@ func TestResolveLanguages(t *testing.T) {
 		orionExtDir string
 		want        []string
 	}{
-		// Orion auto-add is gated on ENABLE_LANGUAGES being set.
 		{
 			name: "empty ENABLE_LANGUAGES returns defaults",
 			want: defaults,
 		},
+		// Orion auto-add applies to defaults too, so setting only
+		// ORION_EXTENSIONS[_DIR] without ENABLE_LANGUAGES still works.
 		{
-			name:     "empty ENABLE_LANGUAGES ignores ORION_EXTENSIONS",
+			name:     "empty ENABLE_LANGUAGES with ORION_EXTENSIONS adds orion to defaults",
 			orionExt: "plugin.star",
-			want:     defaults,
+			want:     append(append([]string{}, defaults...), runner.Orion),
 		},
 		{
-			name:        "empty ENABLE_LANGUAGES ignores ORION_EXTENSIONS_DIR",
+			name:        "empty ENABLE_LANGUAGES with ORION_EXTENSIONS_DIR adds orion to defaults",
 			orionExtDir: "plugins/",
-			want:        defaults,
+			want:        append(append([]string{}, defaults...), runner.Orion),
 		},
 
 		// Explicit list replaces defaults entirely.


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- New test cases added
