### PR TITLE
feat: add js_tsconfig_package_json directive to auto-inject package.json

### DIFF
--- a/language/js/README.md
+++ b/language/js/README.md
@@ -64,4 +64,6 @@ Finally, the `import` statements in the source files are parsed, and dependencie
 | Equivalent to `js_files` but for the test `ts_project` target, or a custom test target. |
 | `# gazelle:js_npm_package_target_name _name_`           | `{dirname}`                 |
 | The format used to generate the name of the `npm_package` target. |
+| `# gazelle:js_tsconfig_package_json enabled\|disabled`  | `disabled`                  |
+| Include `package.json` in generated `ts_project` rules so that TypeScript can determine the module type (ESM vs CJS) from the `"type"` field. When enabled, a local `package.json` is added to `srcs`; if no local `package.json` exists the nearest ancestor that contains one is added as a `dep`.<br />This value is inherited by sub-directories. |
 <!-- prettier-ignore-end -->

--- a/language/js/config.go
+++ b/language/js/config.go
@@ -62,6 +62,9 @@ const (
 	Directive_TestFiles = "js_test_files"
 	// The directive controlling whether asset collection is enabled for import types.
 	Directive_Assets = "js_assets"
+	// En/disable inclusion of package.json in ts_project srcs for TypeScript
+	// module type detection ("type": "module"/"commonjs").
+	Directive_PackageJson = "js_tsconfig_package_json"
 
 	// TODO(deprecated): remove - replaced with js_files [group]
 	Directive_CustomTargetFiles = "js_custom_files"
@@ -200,6 +203,9 @@ type JsGazelleConfig struct {
 	collectAssetImports bool
 	collectAssetJsx     bool
 	collectAssetURL     bool
+
+	packageJsonEnabled bool
+	packageJsonRel     *string
 
 	// Generated rule names
 	npmLinkAllTargetName       string
@@ -480,6 +486,21 @@ func (c *JsGazelleConfig) SetCollectAssetsFrom(kinds ...ImportKind) {
 			c.collectAssetURL = true
 		}
 	}
+}
+
+// PackageJsonEnabled returns whether package.json inclusion in ts_project srcs is enabled.
+func (c *JsGazelleConfig) PackageJsonEnabled() bool {
+	return c.packageJsonEnabled
+}
+
+// PackageJsonRel returns the workspace-relative path of the nearest directory
+// containing a package.json and true, or ("", false) if none has been found.
+// Only returns a value when packageJsonEnabled is true.
+func (c *JsGazelleConfig) PackageJsonRel() (string, bool) {
+	if !c.packageJsonEnabled || c.packageJsonRel == nil {
+		return "", false
+	}
+	return *c.packageJsonRel, true
 }
 
 func (c *JsGazelleConfig) CollectAssetsFrom(kind ImportKind) bool {

--- a/language/js/configure.go
+++ b/language/js/configure.go
@@ -56,6 +56,7 @@ func (ts *typeScriptLang) KnownDirectives() []string {
 		Directive_LibraryFiles,
 		Directive_TestFiles,
 		Directive_Assets,
+		Directive_PackageJson,
 
 		// TODO(deprecated): remove
 		Directive_CustomTargetFiles,
@@ -108,6 +109,12 @@ func (ts *typeScriptLang) readConfigurations(c *config.Config, rel string) {
 			ts.tsconfig.SetTsConfigFile(c.RepoRoot, rel, groupName, tc.fileName)
 		}
 	}
+
+	// Track the nearest package.json for TypeScript module type detection.
+	// This is inherited by child directories so they can add a dep on it.
+	if config.packageJsonEnabled && common.WalkHasPath(rel, NpmPackageFilename) {
+		config.packageJsonRel = &rel
+	}
 }
 
 func (ts *typeScriptLang) readDirectives(c *config.Config, rel string, f *rule.File) {
@@ -128,6 +135,8 @@ func (ts *typeScriptLang) readDirectives(c *config.Config, rel string, f *rule.F
 			config.SetTsConfigGenerationEnabled(groupName, strings.TrimSpace(groupValue) == "enabled")
 		case Directive_TypeScriptProtoExtension:
 			config.SetProtoGenerationEnabled(common.ReadEnabled(d))
+		case Directive_PackageJson:
+			config.packageJsonEnabled = common.ReadEnabled(d)
 		case Directive_NpmPackageExtension:
 			if strings.TrimSpace(d.Value) == string(NpmPackageReferencedMode) {
 				config.SetNpmPackageGenerationMode(NpmPackageReferencedMode)

--- a/language/js/generate.go
+++ b/language/js/generate.go
@@ -561,6 +561,27 @@ func (ts *typeScriptLang) addProjectRule(cfg *JsGazelleConfig, tsconfigRel strin
 		}
 	}
 
+	// When enabled via "# gazelle:js_tsconfig_package_json enabled", include the
+	// package.json file so TypeScript can determine the module type (ESM vs CJS)
+	// via the "type" field. If one exists locally it is added as a source;
+	// otherwise a dep on the nearest ancestor package.json is added so that tsc
+	// can still find it in the sandbox.
+	if cfg.PackageJsonEnabled() {
+		if slices.Contains(args.RegularFiles, NpmPackageFilename) {
+			info.sources.Add(NpmPackageFilename)
+		} else if packageJsonRel, ok := cfg.PackageJsonRel(); ok {
+			info.AddImport(ImportStatement{
+				ImportSpec: resolve.ImportSpec{
+					Lang: LanguageName,
+					Imp:  path.Join(packageJsonRel, NpmPackageFilename),
+				},
+				ImportPath: NpmPackageFilename,
+				SourcePath: path.Join(args.Rel, NpmPackageFilename),
+				Optional:   true,
+			})
+		}
+	}
+
 	// A rule of the same name might already exist
 	existing := ruleUtils.GetFileRuleByName(args, targetName)
 

--- a/language/js/tests/simple_package_json/BUILD.in
+++ b/language/js/tests/simple_package_json/BUILD.in
@@ -1,0 +1,1 @@
+# gazelle:js_tsconfig_package_json enabled

--- a/language/js/tests/simple_package_json/BUILD.out
+++ b/language/js/tests/simple_package_json/BUILD.out
@@ -1,0 +1,11 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+# gazelle:js_tsconfig_package_json enabled
+
+ts_project(
+    name = "simple_package_json",
+    srcs = [
+        "main.ts",
+        "package.json",
+    ],
+)

--- a/language/js/tests/simple_package_json/WORKSPACE
+++ b/language/js/tests/simple_package_json/WORKSPACE
@@ -1,0 +1,2 @@
+# This is a Bazel workspace for the Gazelle test data.
+workspace(name = "simple_package_json")

--- a/language/js/tests/simple_package_json/main.ts
+++ b/language/js/tests/simple_package_json/main.ts
@@ -1,0 +1,1 @@
+export const hello = "world";

--- a/language/js/tests/simple_package_json/package.json
+++ b/language/js/tests/simple_package_json/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}

--- a/language/js/tests/simple_package_json/subdir/BUILD.out
+++ b/language/js/tests/simple_package_json/subdir/BUILD.out
@@ -1,0 +1,7 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+ts_project(
+    name = "subdir",
+    srcs = ["lib.ts"],
+    deps = ["//:simple_package_json"],
+)

--- a/language/js/tests/simple_package_json/subdir/disabled/BUILD.in
+++ b/language/js/tests/simple_package_json/subdir/disabled/BUILD.in
@@ -1,0 +1,1 @@
+# gazelle:js_tsconfig_package_json disabled

--- a/language/js/tests/simple_package_json/subdir/disabled/BUILD.out
+++ b/language/js/tests/simple_package_json/subdir/disabled/BUILD.out
@@ -1,0 +1,8 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+# gazelle:js_tsconfig_package_json disabled
+
+ts_project(
+    name = "disabled",
+    srcs = ["app.ts"],
+)

--- a/language/js/tests/simple_package_json/subdir/disabled/app.ts
+++ b/language/js/tests/simple_package_json/subdir/disabled/app.ts
@@ -1,0 +1,1 @@
+export const app = "disabled";

--- a/language/js/tests/simple_package_json/subdir/disabled/nested/BUILD.out
+++ b/language/js/tests/simple_package_json/subdir/disabled/nested/BUILD.out
@@ -1,0 +1,6 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+ts_project(
+    name = "nested",
+    srcs = ["app.ts"],
+)

--- a/language/js/tests/simple_package_json/subdir/disabled/nested/app.ts
+++ b/language/js/tests/simple_package_json/subdir/disabled/nested/app.ts
@@ -1,0 +1,1 @@
+export const nested = "also disabled";

--- a/language/js/tests/simple_package_json/subdir/disabled/reenabled/BUILD.in
+++ b/language/js/tests/simple_package_json/subdir/disabled/reenabled/BUILD.in
@@ -1,0 +1,1 @@
+# gazelle:js_tsconfig_package_json enabled

--- a/language/js/tests/simple_package_json/subdir/disabled/reenabled/BUILD.out
+++ b/language/js/tests/simple_package_json/subdir/disabled/reenabled/BUILD.out
@@ -1,0 +1,9 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+# gazelle:js_tsconfig_package_json enabled
+
+ts_project(
+    name = "reenabled",
+    srcs = ["app.ts"],
+    deps = ["//:simple_package_json"],
+)

--- a/language/js/tests/simple_package_json/subdir/disabled/reenabled/app.ts
+++ b/language/js/tests/simple_package_json/subdir/disabled/reenabled/app.ts
@@ -1,0 +1,1 @@
+export const reenabled = "back on";

--- a/language/js/tests/simple_package_json/subdir/lib.ts
+++ b/language/js/tests/simple_package_json/subdir/lib.ts
@@ -1,0 +1,1 @@
+export const lib = "subdir";

--- a/language/js/tests/simple_package_json/subdir/midpkg/BUILD.out
+++ b/language/js/tests/simple_package_json/subdir/midpkg/BUILD.out
@@ -1,0 +1,9 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+ts_project(
+    name = "midpkg",
+    srcs = [
+        "index.ts",
+        "package.json",
+    ],
+)

--- a/language/js/tests/simple_package_json/subdir/midpkg/deep/BUILD.out
+++ b/language/js/tests/simple_package_json/subdir/midpkg/deep/BUILD.out
@@ -1,0 +1,7 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+ts_project(
+    name = "deep",
+    srcs = ["app.ts"],
+    deps = ["//subdir/midpkg"],
+)

--- a/language/js/tests/simple_package_json/subdir/midpkg/deep/app.ts
+++ b/language/js/tests/simple_package_json/subdir/midpkg/deep/app.ts
@@ -1,0 +1,1 @@
+export const deep = "inherits midpkg package.json";

--- a/language/js/tests/simple_package_json/subdir/midpkg/index.ts
+++ b/language/js/tests/simple_package_json/subdir/midpkg/index.ts
@@ -1,0 +1,1 @@
+export const mid = "has own package.json";

--- a/language/js/tests/simple_package_json/subdir/midpkg/package.json
+++ b/language/js/tests/simple_package_json/subdir/midpkg/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "commonjs"
+}


### PR DESCRIPTION
Adds a js_tsconfig_package_json directive, which allows enabling the auto-injection of package.json as a dependency to ts_project. This allows the package.json 'type' field to be used to determine whether the module type is ESM or CJS.

This is particularly important in some configurations, such as when verbatimModuleSyntax is enabled

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

> Added a new `# gazelle:js_tsconfig_package_json enabled\|disabled` directive which can be used to enable listing package.json as a dependency of ts_project. Useful for allowing TS to determine the module type (ESM or CJS) to be allowed.

### Test plan

- Covered by existing test cases: existing cases prove default behavior remains unchanged (although the default should possibly be set to `true` at some stage?)
- New test cases added: yes, added test cases to mirror some different file structures and enabling/disabling the rule