### PR TITLE
feat: add prebuilt --cache=disk|watchman and caching when invoked as --watch client

### DIFF
--- a/common/cache/BUILD.bazel
+++ b/common/cache/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "disk.go",
         "filecompute.go",
         "noop.go",
+        "watch.go",
     ],
     importpath = "github.com/aspect-build/aspect-gazelle/common/cache",
     visibility = ["//visibility:public"],
@@ -25,6 +26,7 @@ go_test(
     srcs = [
         "disk_test.go",
         "filecompute_test.go",
+        "watch_test.go",
     ],
     embed = [":cache"],
     deps = ["@gazelle//config"],

--- a/common/cache/README.md
+++ b/common/cache/README.md
@@ -2,7 +2,15 @@
 
 This package provides utilities for caching within or across Gazelle invocations.
 
-File based caching is enabled by setting `ASPECT_GAZELLE_CACHE` to a path (e.g. `.cache/aspect-gazelle.cache`) for loading+persisting the cache between Gazelle runs.
+File-based caching on the aspect-gazelle binary can be enabled either by flag or by env var:
+
+- `--cache` or `--cache=disk` — persists to a file and invalidates entries on content-hash changes.
+- `--cache=watchman` — persists to a file and invalidates entries via filesystem events from [watchman](https://facebook.github.io/watchman/) (more efficient on large trees; requires `watchman` on `PATH`).
+- `ASPECT_GAZELLE_CACHE=<path>` — sets the cache file location and, when no `--cache` flag is given, implies `--cache=disk`.
+
+When invoked as a `--watch` protocol client the runner automatically installs a watch-optimized disk cache — no flag needed — and invalidates entries based on the watch protocol's change notifications.
+
+The cache file location defaults to `$TMPDIR/aspect-gazelle-<repo>.cache`; set `ASPECT_GAZELLE_CACHE` to override (e.g. `.cache/aspect-gazelle.cache`). The on-disk format is shared between `--cache=disk` and the watch-mode cache, so entries survive mode switches across runs.
 
 ## Usage
 

--- a/common/cache/watch.go
+++ b/common/cache/watch.go
@@ -1,0 +1,69 @@
+package cache
+
+import (
+	"sync"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+)
+
+// WatchCache is a disk-backed cache optimized for long-running watch sessions.
+// The first access to each path in a session runs the disk-cache hash check
+// (catching offline content changes since the last persist); subsequent
+// (path, key) hits for that path return the cached value with no file I/O or
+// hashing. Any miss also goes through the disk-cache path so entries and
+// their content hashes stay in sync on disk. Callers Invalidate paths that
+// change mid-session via an external watch signal.
+//
+// The on-disk format is identical to the disk cache, so entries are
+// interchangeable between the two modes across process restarts.
+type WatchCache struct {
+	*diskCache
+	verified sync.Map // path -> struct{} (hash-checked in this session)
+}
+
+// NewWatchCache returns an unconfigured WatchCache. Install its NewCache as
+// the gazelle cache factory; the persistence file is resolved on first use.
+func NewWatchCache() *WatchCache {
+	return &WatchCache{
+		diskCache: &diskCache{FileComputeCache: NewFileComputeCache()},
+	}
+}
+
+// NewCache is a CacheFactory. Pass it to SetCacheFactory.
+func (c *WatchCache) NewCache(cfg *config.Config) Cache {
+	c.initOnce.Do(func() {
+		c.file = FilePath(cfg)
+		c.read() // diskCache.read — loads entries and content hashes.
+	})
+	return c
+}
+
+// LoadOrStoreFile returns a (path, key) hit with no file I/O once the path
+// has been hash-verified in this session. The first access per path (and any
+// miss) runs through the disk-cache path so the stored hash stays consistent
+// with the stored entry.
+func (c *WatchCache) LoadOrStoreFile(root, p, key string, loader FileCompute) (any, bool, error) {
+	if _, verified := c.verified.Load(p); verified {
+		if e, ok := c.entries.Load(p); ok {
+			if v, found := e.(*fileEntry).load(key); found {
+				return v, true, nil
+			}
+		}
+	}
+	v, cached, err := c.diskCache.LoadOrStoreFile(root, p, key, loader)
+	if err == nil {
+		c.verified.Store(p, struct{}{})
+	}
+	return v, cached, err
+}
+
+// Invalidate drops the entry, its stored content hash, and the verified mark
+// together, so a Persist that follows without re-accessing the path does not
+// leave a stale hash on disk and the next access re-runs the hash check.
+func (c *WatchCache) Invalidate(paths []string) {
+	c.FileComputeCache.Invalidate(paths)
+	for _, p := range paths {
+		c.contentHashes.Delete(p)
+		c.verified.Delete(p)
+	}
+}

--- a/common/cache/watch_test.go
+++ b/common/cache/watch_test.go
@@ -1,0 +1,301 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newWatchCacheAt returns a WatchCache backed by the given path with no initial disk read.
+func newWatchCacheAt(t *testing.T, file string) *WatchCache {
+	t.Helper()
+	wc := NewWatchCache()
+	wc.file = file
+	return wc
+}
+
+// newWatchCacheLoading returns a WatchCache that reads an existing file.
+func newWatchCacheLoading(t *testing.T, file string) *WatchCache {
+	t.Helper()
+	wc := newWatchCacheAt(t, file)
+	wc.read()
+	return wc
+}
+
+func TestWatchCache_Miss(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "file.go", "content")
+
+	c := newWatchCacheAt(t, filepath.Join(dir, "cache"))
+	compute, calls := makeCompute(t)
+
+	v, hit, err := c.LoadOrStoreFile(dir, "file.go", "key", compute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hit {
+		t.Error("expected miss on first load")
+	}
+	if v.(string) != "content" {
+		t.Errorf("expected %q, got %q", "content", v)
+	}
+	if *calls != 1 {
+		t.Errorf("expected 1 compute call, got %d", *calls)
+	}
+}
+
+// Cached (path, key) hits return the stored value without file I/O, even when content changed on disk.
+func TestWatchCache_HitIgnoresFileChange(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "file.go", "v1")
+
+	c := newWatchCacheAt(t, filepath.Join(dir, "cache"))
+	compute, calls := makeCompute(t)
+
+	c.LoadOrStoreFile(dir, "file.go", "key", compute)
+
+	writeTestFile(t, dir, "file.go", "v2")
+
+	v, hit, err := c.LoadOrStoreFile(dir, "file.go", "key", compute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hit {
+		t.Error("expected hit: watch cache must not revalidate on file change")
+	}
+	if v.(string) != "v1" {
+		t.Errorf("expected stale %q, got %q", "v1", v)
+	}
+	if *calls != 1 {
+		t.Errorf("expected no additional compute call, got %d", *calls)
+	}
+}
+
+// Different keys on the same path each miss on first access and share a stored entry.
+func TestWatchCache_MultipleOpsPerFile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "file.go", "content")
+
+	c := newWatchCacheAt(t, filepath.Join(dir, "cache"))
+	compute, calls := makeCompute(t)
+
+	_, hit1, _ := c.LoadOrStoreFile(dir, "file.go", "op1", compute)
+	_, hit2, _ := c.LoadOrStoreFile(dir, "file.go", "op2", compute)
+
+	if hit1 || hit2 {
+		t.Error("expected misses on first load of each op key")
+	}
+	if *calls != 2 {
+		t.Errorf("expected 2 compute calls, got %d", *calls)
+	}
+
+	_, hit3, _ := c.LoadOrStoreFile(dir, "file.go", "op1", compute)
+	_, hit4, _ := c.LoadOrStoreFile(dir, "file.go", "op2", compute)
+
+	if !hit3 || !hit4 {
+		t.Error("expected hits on second load of each op key")
+	}
+	if *calls != 2 {
+		t.Errorf("expected no additional compute calls, got %d", *calls)
+	}
+}
+
+func TestWatchCache_Invalidate(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "file.go", "v1")
+
+	c := newWatchCacheAt(t, filepath.Join(dir, "cache"))
+	compute, calls := makeCompute(t)
+
+	c.LoadOrStoreFile(dir, "file.go", "key", compute)
+
+	writeTestFile(t, dir, "file.go", "v2")
+	c.Invalidate([]string{"file.go"})
+
+	v, hit, err := c.LoadOrStoreFile(dir, "file.go", "key", compute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hit {
+		t.Error("expected miss after Invalidate")
+	}
+	if v.(string) != "v2" {
+		t.Errorf("expected fresh %q, got %q", "v2", v)
+	}
+	if *calls != 2 {
+		t.Errorf("expected 2 compute calls, got %d", *calls)
+	}
+}
+
+// Invalidate clears both the cached entry and the content hash so a follow-up Persist doesn't leave a stale hash.
+func TestWatchCache_InvalidateClearsContentHash(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "file.go", "content")
+
+	c := newWatchCacheAt(t, filepath.Join(dir, "cache"))
+	compute, _ := makeCompute(t)
+
+	c.LoadOrStoreFile(dir, "file.go", "key", compute)
+
+	if _, ok := c.contentHashes.Load("file.go"); !ok {
+		t.Fatal("expected content hash to be stored after first load")
+	}
+	if _, ok := c.entries.Load("file.go"); !ok {
+		t.Fatal("expected entry to be stored after first load")
+	}
+
+	c.Invalidate([]string{"file.go"})
+
+	if _, ok := c.contentHashes.Load("file.go"); ok {
+		t.Error("expected content hash to be cleared by Invalidate")
+	}
+	if _, ok := c.entries.Load("file.go"); ok {
+		t.Error("expected entry to be cleared by Invalidate")
+	}
+}
+
+// After Invalidate + Persist with no re-access, the persisted file omits entry and hash — warm start can't accept a stale hash.
+func TestWatchCache_InvalidateBeforePersist(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "file.go", "v1")
+	cacheFile := filepath.Join(dir, "cache")
+
+	c1 := newWatchCacheAt(t, cacheFile)
+	compute1, _ := makeCompute(t)
+	c1.LoadOrStoreFile(dir, "file.go", "key", compute1)
+
+	c1.Invalidate([]string{"file.go"})
+	c1.Persist()
+
+	c2 := newWatchCacheLoading(t, cacheFile)
+
+	if _, ok := c2.contentHashes.Load("file.go"); ok {
+		t.Error("expected persisted cache to omit hash for invalidated path")
+	}
+	if _, ok := c2.entries.Load("file.go"); ok {
+		t.Error("expected persisted cache to omit entry for invalidated path")
+	}
+}
+
+func TestWatchCache_Persistence(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "file.go", "content")
+	cacheFile := filepath.Join(dir, "cache")
+
+	c1 := newWatchCacheAt(t, cacheFile)
+	compute1, _ := makeCompute(t)
+	c1.LoadOrStoreFile(dir, "file.go", "key", compute1)
+	c1.Persist()
+
+	c2 := newWatchCacheLoading(t, cacheFile)
+	compute2, calls2 := makeCompute(t)
+	_, hit, err := c2.LoadOrStoreFile(dir, "file.go", "key", compute2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hit {
+		t.Error("expected hit from persisted cache")
+	}
+	if *calls2 != 0 {
+		t.Errorf("expected 0 compute calls after reload, got %d", *calls2)
+	}
+}
+
+func TestWatchCache_WarmStartDetectsOfflineChange(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "file.go", "v1")
+	cacheFile := filepath.Join(dir, "cache")
+
+	c1 := newWatchCacheAt(t, cacheFile)
+	compute1, _ := makeCompute(t)
+	c1.LoadOrStoreFile(dir, "file.go", "key", compute1)
+	c1.Persist()
+
+	// File changes while no watch session is active (offline change).
+	writeTestFile(t, dir, "file.go", "v2")
+
+	c2 := newWatchCacheLoading(t, cacheFile)
+	compute2, calls2 := makeCompute(t)
+	v, hit, err := c2.LoadOrStoreFile(dir, "file.go", "key", compute2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hit {
+		t.Error("expected miss: warm-start must detect offline content change")
+	}
+	if v.(string) != "v2" {
+		t.Errorf("expected %q, got %q", "v2", v)
+	}
+	if *calls2 != 1 {
+		t.Errorf("expected 1 compute call, got %d", *calls2)
+	}
+}
+
+func TestWatchCache_DiskFormatInterop(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "file.go", "content")
+	cacheFile := filepath.Join(dir, "cache")
+
+	d := NewDiskCache(cacheFile)
+	compute1, _ := makeCompute(t)
+	d.LoadOrStoreFile(dir, "file.go", "key", compute1)
+	d.Persist()
+
+	w := newWatchCacheLoading(t, cacheFile)
+	compute2, calls2 := makeCompute(t)
+	_, hit, err := w.LoadOrStoreFile(dir, "file.go", "key", compute2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hit {
+		t.Error("expected hit: watch cache should read a disk-cache file")
+	}
+	if *calls2 != 0 {
+		t.Errorf("expected 0 compute calls after reload, got %d", *calls2)
+	}
+}
+
+// A new key on an already-verified path re-runs the disk-cache path so the stored hash stays in lockstep with the entry.
+func TestWatchCache_KeyMissOnVerifiedPathUpdatesHash(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "file.go", "v1")
+
+	c := newWatchCacheAt(t, filepath.Join(dir, "cache"))
+	compute, _ := makeCompute(t)
+
+	c.LoadOrStoreFile(dir, "file.go", "op1", compute)
+
+	h1, ok := c.contentHashes.Load("file.go")
+	if !ok {
+		t.Fatal("expected hash stored after first load")
+	}
+
+	writeTestFile(t, dir, "file.go", "v2")
+	c.LoadOrStoreFile(dir, "file.go", "op2", compute)
+
+	h2, _ := c.contentHashes.Load("file.go")
+	if h1 == h2 {
+		t.Error("expected content hash updated when new content was read for a new key")
+	}
+}
+
+func TestWatchCache_NewCacheIsSingleton(t *testing.T) {
+	dir := t.TempDir()
+	cacheFile := filepath.Join(dir, "cache")
+	t.Setenv("ASPECT_GAZELLE_CACHE", cacheFile)
+
+	wc := NewWatchCache()
+	a := wc.NewCache(fakeConfig("repo"))
+	b := wc.NewCache(fakeConfig("repo"))
+
+	if a != b {
+		t.Error("expected NewCache to return the same instance each call")
+	}
+
+	// A second NewCache call should not re-read the file.
+	if err := os.WriteFile(cacheFile, []byte("garbage"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = wc.NewCache(fakeConfig("repo"))
+}

--- a/runner/bin/gazelle/BUILD.bazel
+++ b/runner/bin/gazelle/BUILD.bazel
@@ -13,8 +13,11 @@ go_library(
     deps = [
         "//:runner",
         "//pkg/ibp",
+        "//pkg/watchman",
         "@aspect_gazelle//common/bazel",
+        "@aspect_gazelle//common/cache",
         "@aspect_gazelle//common/logger",
+        "@gazelle//config",
     ],
 )
 

--- a/runner/bin/gazelle/args.go
+++ b/runner/bin/gazelle/args.go
@@ -8,10 +8,19 @@ import (
 	"github.com/aspect-build/aspect-gazelle/runner"
 )
 
+// cacheType selects a cache implementation for --cache[=disk|watchman].
+type cacheType string
+
+const (
+	cacheDefault  cacheType = ""
+	cacheDisk     cacheType = "disk"
+	cacheWatchman cacheType = "watchman"
+)
+
 /**
  * Parse and extract arguments not directly passed along to gazelle.
  */
-func parseArgs(args []string) (runner.GazelleCommand, runner.GazelleMode, bool, []string) {
+func parseArgs(args []string) (runner.GazelleCommand, runner.GazelleMode, bool, cacheType, []string) {
 	// The optional initial command argument
 	cmd := runner.UpdateCmd
 	if len(args) > 0 && (args[0] == runner.UpdateCmd || args[0] == runner.FixCmd) {
@@ -25,7 +34,16 @@ func parseArgs(args []string) (runner.GazelleCommand, runner.GazelleMode, bool, 
 	// The optional --progress flag
 	progress, args := extractFlag("progress", false, args)
 
-	return cmd, mode, progress, args
+	// The optional --cache[=disk|watchman] flag; bare --cache defaults to disk.
+	cacheRaw, args := extractOptionalArg("cache", string(cacheDisk), args)
+	ct := cacheType(cacheRaw)
+	switch ct {
+	case cacheDefault, cacheDisk, cacheWatchman:
+	default:
+		log.Fatalf("ERROR: invalid --cache value %q, expected \"disk\" or \"watchman\"", cacheRaw)
+	}
+
+	return cmd, mode, progress, ct, args
 }
 
 func extractFlag(flag string, defaultValue bool, args []string) (bool, []string) {
@@ -69,4 +87,24 @@ func extractArg(flag string, defaultValue string, args []string) (string, []stri
 
 	args = slices.Delete(args, i, i+1)
 	return value, args
+}
+
+// Extract a --flag[=value] flag. Bare --flag returns defaultBare without consuming a following token.
+func extractOptionalArg(flag, defaultBare string, args []string) (string, []string) {
+	f1 := "-" + flag
+	f2 := "--" + flag
+
+	i := slices.IndexFunc(args, func(s string) bool {
+		return s == f1 || s == f2 || strings.HasPrefix(s, f1+"=") || strings.HasPrefix(s, f2+"=")
+	})
+
+	if i == -1 {
+		return "", args
+	}
+
+	_, value, _ := strings.Cut(args[i], "=")
+	if value == "" {
+		value = defaultBare
+	}
+	return value, slices.Delete(args, i, i+1)
 }

--- a/runner/bin/gazelle/args_test.go
+++ b/runner/bin/gazelle/args_test.go
@@ -9,12 +9,13 @@ import (
 
 func TestParseArgs(t *testing.T) {
 	cases := []struct {
-		name     string
-		argv     []string
-		wantCmd  runner.GazelleCommand
-		wantMode runner.GazelleMode
-		wantProg bool
-		wantArgs []string
+		name      string
+		argv      []string
+		wantCmd   runner.GazelleCommand
+		wantMode  runner.GazelleMode
+		wantProg  bool
+		wantCache cacheType
+		wantArgs  []string
 	}{
 		// Default: `gazelle` with no args -> update + fix (matches bazel-gazelle default command).
 		{
@@ -166,7 +167,7 @@ func TestParseArgs(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd, mode, progress, args := parseArgs(tc.argv)
+			cmd, mode, progress, ct, args := parseArgs(tc.argv)
 			if cmd != tc.wantCmd {
 				t.Errorf("cmd: got %q, want %q", cmd, tc.wantCmd)
 			}
@@ -175,6 +176,9 @@ func TestParseArgs(t *testing.T) {
 			}
 			if progress != tc.wantProg {
 				t.Errorf("progress: got %v, want %v", progress, tc.wantProg)
+			}
+			if ct != tc.wantCache {
+				t.Errorf("cache: got %q, want %q", ct, tc.wantCache)
 			}
 			if !reflect.DeepEqual(args, tc.wantArgs) {
 				t.Errorf("args: got %v, want %v", args, tc.wantArgs)
@@ -408,9 +412,95 @@ func TestProgressFlag(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, progress, args := parseArgs(tc.argv)
+			_, _, progress, _, args := parseArgs(tc.argv)
 			if progress != tc.wantProg {
 				t.Errorf("progress: got %v, want %v", progress, tc.wantProg)
+			}
+			if !reflect.DeepEqual(args, tc.wantArgs) {
+				t.Errorf("args: got %v, want %v", args, tc.wantArgs)
+			}
+		})
+	}
+}
+
+// TestCacheFlag covers the aspect-specific --cache[=disk|watchman] flag.
+func TestCacheFlag(t *testing.T) {
+	cases := []struct {
+		name      string
+		argv      []string
+		wantCache cacheType
+		wantArgs  []string
+	}{
+		{
+			name:      "default is off",
+			argv:      []string{},
+			wantCache: cacheDefault,
+			wantArgs:  []string{},
+		},
+		{
+			name:      "bare --cache enables disk",
+			argv:      []string{"--cache"},
+			wantCache: cacheDisk,
+			wantArgs:  []string{},
+		},
+		{
+			name:      "bare -cache enables disk",
+			argv:      []string{"-cache"},
+			wantCache: cacheDisk,
+			wantArgs:  []string{},
+		},
+		{
+			name:      "--cache=disk",
+			argv:      []string{"--cache=disk"},
+			wantCache: cacheDisk,
+			wantArgs:  []string{},
+		},
+		{
+			name:      "--cache=watchman",
+			argv:      []string{"--cache=watchman"},
+			wantCache: cacheWatchman,
+			wantArgs:  []string{},
+		},
+		{
+			name:      "-cache=watchman",
+			argv:      []string{"-cache=watchman"},
+			wantCache: cacheWatchman,
+			wantArgs:  []string{},
+		},
+		{
+			name:      "--cache= (empty) treated as bare",
+			argv:      []string{"--cache="},
+			wantCache: cacheDisk,
+			wantArgs:  []string{},
+		},
+		{
+			// --cache does NOT consume a following positional arg as its value,
+			// unlike --mode. This matches the cli's stdlib IsBoolFlag behavior.
+			name:      "bare --cache does not consume following positional",
+			argv:      []string{"--cache", "pkg/foo"},
+			wantCache: cacheDisk,
+			wantArgs:  []string{"pkg/foo"},
+		},
+		{
+			name:      "consumed from forwarded args",
+			argv:      []string{"--cache=disk", "-mode=diff", "pkg"},
+			wantCache: cacheDisk,
+			wantArgs:  []string{"pkg"},
+		},
+		{
+			// Substring name is not matched.
+			name:      "--cach (typo) does not match",
+			argv:      []string{"--cach"},
+			wantCache: cacheDefault,
+			wantArgs:  []string{"--cach"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, ct, args := parseArgs(tc.argv)
+			if ct != tc.wantCache {
+				t.Errorf("cache: got %q, want %q", ct, tc.wantCache)
 			}
 			if !reflect.DeepEqual(args, tc.wantArgs) {
 				t.Errorf("args: got %v, want %v", args, tc.wantArgs)

--- a/runner/bin/gazelle/main.go
+++ b/runner/bin/gazelle/main.go
@@ -5,8 +5,11 @@ import (
 	"os"
 
 	"github.com/aspect-build/aspect-gazelle/common/bazel"
+	"github.com/aspect-build/aspect-gazelle/common/cache"
 	"github.com/aspect-build/aspect-gazelle/runner"
 	"github.com/aspect-build/aspect-gazelle/runner/pkg/ibp"
+	"github.com/aspect-build/aspect-gazelle/runner/pkg/watchman"
+	"github.com/bazelbuild/bazel-gazelle/config"
 )
 
 /**
@@ -21,7 +24,7 @@ func main() {
 
 	wd := bazel.FindWorkspaceDirectory()
 
-	cmd, mode, progress, args := parseArgs(os.Args[1:])
+	cmd, mode, progress, ct, args := parseArgs(os.Args[1:])
 
 	c := runner.New(wd, progress)
 
@@ -36,6 +39,15 @@ func main() {
 			log.Fatalf("Error running gazelle watcher: %v", err)
 		}
 	} else {
+		switch ct {
+		case cacheDisk:
+			cache.SetCacheFactory(func(c *config.Config) cache.Cache {
+				return cache.NewDiskCache(cache.FilePath(c))
+			})
+		case cacheWatchman:
+			cache.SetCacheFactory(watchman.NewWatchmanCache)
+		}
+
 		hasChanges, err := c.Generate(cmd, mode, args)
 		if err != nil {
 			log.Fatalf("Error running gazelle: %v", err)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -225,6 +225,11 @@ func (p *GazelleRunner) Watch(watchAddress string, cmd GazelleCommand, mode Gaze
 
 	defer watch.Disconnect()
 
+	// Cache hits skip file I/O; misses hash-verify via the disk cache.
+	// CYCLE messages evict entries mid-session (see loop below).
+	wc := cache.NewWatchCache()
+	cache.SetCacheFactory(wc.NewCache)
+
 	// Params for the underlying gazelle call
 	fixArgs := p.prepareGazelleArgs(mode, args)
 
@@ -257,6 +262,13 @@ func (p *GazelleRunner) Watch(watchAddress string, cmd GazelleCommand, mode Gaze
 		}
 
 		_, t := p.tracer.Start(ctx, "GazelleRunner.Watch.Trigger")
+
+		// Evict cache entries for paths the protocol reports changed.
+		changedPaths := make([]string, 0, len(cs.Sources))
+		for f := range cs.Sources {
+			changedPaths = append(changedPaths, f)
+		}
+		wc.Invalidate(changedPaths)
 
 		// The directories that have changed which gazelle should update.
 		// This assumes all enabled gazelle languages support incremental updates.


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Add `aspect_gazelle` binary `--cache[=disk|watchman]`.
Add automatic caching when `aspect_gazelle` invoked using the incremental-build-protocol such as `run --watch` from the Aspect CLI.

### Test plan

- Covered by existing test cases
- New test cases added
- Manual testing; `run --watch`
