### PR TITLE
refactor: use sync.Once for cache FileComputeCache init

### DIFF
--- a/common/cache/disk.go
+++ b/common/cache/disk.go
@@ -133,7 +133,7 @@ func (c *diskCache) LoadOrStoreFile(root, p, key string, loader FileCompute) (an
 	// Invalidate the cached entry if the file content has changed.
 	if existingHash, found := c.contentHashes.Load(p); found {
 		if existingHash.(string) != contentHash {
-			c.Invalidate([]string{p})
+			c.FileComputeCache.Invalidate([]string{p})
 		}
 	}
 	c.contentHashes.Store(p, contentHash)

--- a/common/cache/filecompute.go
+++ b/common/cache/filecompute.go
@@ -35,9 +35,9 @@ type fileComputeCacheState struct {
 // It implements Cache directly and can be embedded by caches that need to
 // augment its behaviour (e.g. symlink resolution or extra metadata).
 type FileComputeCache struct {
-	entries     *sync.Map // string → *fileEntry
-	file        string
-	initialized bool
+	entries  *sync.Map
+	file     string
+	initOnce sync.Once
 }
 
 var _ Cache = (*FileComputeCache)(nil)
@@ -83,11 +83,10 @@ func (c *FileComputeCache) SnapshotEntries() map[string]map[string]any {
 
 // NewCache is a CacheFactory. Pass it to SetCacheFactory.
 func (c *FileComputeCache) NewCache(cfg *config.Config) Cache {
-	if !c.initialized {
-		c.initialized = true
+	c.initOnce.Do(func() {
 		c.file = FilePath(cfg)
 		c.read()
-	}
+	})
 	return c
 }
 

--- a/common/cache/filecompute_test.go
+++ b/common/cache/filecompute_test.go
@@ -20,7 +20,6 @@ func newFileComputeCacheAt(t *testing.T, file string) *FileComputeCache {
 	t.Helper()
 	c := NewFileComputeCache()
 	c.file = file
-	c.initialized = true
 	return c
 }
 


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
