### PR TITLE
fix: tree-sitter #eq? should follow tree-sitter spec

### DIFF
--- a/common/treesitter/filters.go
+++ b/common/treesitter/filters.go
@@ -13,9 +13,14 @@ import (
 // Examples of additional standard tree-sitter predicates:
 //   - https://tree-sitter.github.io/tree-sitter/using-parsers#predicates
 //
+// Spec reference:
+//   - https://tree-sitter.github.io/tree-sitter/using-parsers/queries/3-predicates-and-directives.html
+//
 // Predicates implemented here:
-//   - eq?
-//   - match?
+//   - eq?, not-eq?
+//   - match?, not-match?
+//
+// Not implemented: any-eq?, any-not-eq?, any-match?, any-not-match?, any-of?, not-any-of?, is?, is-not?, set!.
 func matchesAllPredicates(q *sitterQuery, m *sitter.QueryMatch, qc *sitter.QueryCursor, input []byte) bool {
 	predicates := q.PredicatesForPattern(uint32(m.PatternIndex))
 	if len(predicates) == 0 {
@@ -35,22 +40,25 @@ func matchesAllPredicates(q *sitterQuery, m *sitter.QueryMatch, qc *sitter.Query
 			if steps[2].Type == sitter.QueryPredicateStepTypeCapture {
 				expectedCaptureNameRight := q.CaptureNameForId(steps[2].ValueId)
 
-				var nodeLeft, nodeRight *sitter.Node
-
+				// Pairwise + equal-length, per tree-sitter reference impl:
+				// https://github.com/tree-sitter/tree-sitter/blob/master/lib/binding_rust/lib.rs
+				var leftContents, rightContents []string
 				for _, c := range m.Captures {
 					captureName := q.CaptureNameForId(c.Index)
-
 					if captureName == expectedCaptureNameLeft {
-						nodeLeft = c.Node
+						leftContents = append(leftContents, c.Node.Content(input))
 					}
 					if captureName == expectedCaptureNameRight {
-						nodeRight = c.Node
+						rightContents = append(rightContents, c.Node.Content(input))
 					}
+				}
 
-					if nodeLeft != nil && nodeRight != nil {
-						if (nodeLeft.Content(input) == nodeRight.Content(input)) != isPositive {
-							return false
-						}
+				if len(leftContents) != len(rightContents) {
+					return false
+				}
+				for i := range leftContents {
+					if (leftContents[i] == rightContents[i]) != isPositive {
+						return false
 					}
 				}
 			} else {

--- a/common/treesitter/filters_test.go
+++ b/common/treesitter/filters_test.go
@@ -42,6 +42,14 @@ func collectCaptures(ast treesitter.AST, q treesitter.TreeQuery, capture string)
 	return results
 }
 
+func countMatches(ast treesitter.AST, q treesitter.TreeQuery) int {
+	n := 0
+	for range ast.Query(q) {
+		n++
+	}
+	return n
+}
+
 const goFunctions = `package foo
 
 func Foo() {}
@@ -108,6 +116,104 @@ func TestEqPredicateCaptureVsCapture_match(t *testing.T) {
 	want := []string{`"same"`}
 	if !slices.Equal(got, want) {
 		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// @a=["Outer","Inner"], @b=["Inner"] — mismatched lengths must reject.
+func TestEqPredicate_quantifiedCaptureLengthMismatch(t *testing.T) {
+	src := `package foo
+
+func Outer() {
+	Inner()
+	Inner()
+}
+`
+	ast := mustParseGo(t, src)
+	q := mustQuery(t, `(function_declaration
+		name: (identifier) @a
+		body: (block (statement_list
+			(expression_statement (call_expression function: (identifier) @a))
+			(expression_statement (call_expression function: (identifier) @b))))
+		(#eq? @a @b))`)
+
+	got := collectCaptures(ast, q, "a")
+	if len(got) != 0 {
+		t.Errorf("expected no matches, got %v", got)
+	}
+}
+
+// #eq? with a quantified capture: all bindings must equal the literal.
+func TestEqPredicate_quantifiedVsLiteral(t *testing.T) {
+	q := mustQuery(t, `(literal_value
+		(keyed_element key: (literal_element (interpreted_string_literal) @k))
+		(keyed_element key: (literal_element (interpreted_string_literal) @k))
+		(#eq? @k "\"foo\""))`)
+
+	allMatch := mustParseGo(t, `package foo
+var _ = map[string]int{"foo": 1, "foo": 2}
+`)
+	if n := countMatches(allMatch, q); n != 1 {
+		t.Errorf("all-match: got %d, want 1", n)
+	}
+
+	oneDiffers := mustParseGo(t, `package foo
+var _ = map[string]int{"foo": 1, "bar": 2}
+`)
+	if n := countMatches(oneDiffers, q); n != 0 {
+		t.Errorf("one-differs: got %d, want 0", n)
+	}
+}
+
+// #match? with a quantified capture: all bindings must match the regex.
+func TestMatchPredicate_quantifiedVsRegex(t *testing.T) {
+	q := mustQuery(t, `(source_file
+		(function_declaration name: (identifier) @n)
+		(function_declaration name: (identifier) @n)
+		(#match? @n "^[A-Z]"))`)
+
+	allMatch := mustParseGo(t, `package foo
+func Foo() {}
+func Bar() {}
+`)
+	if n := countMatches(allMatch, q); n != 1 {
+		t.Errorf("all-match: got %d, want 1", n)
+	}
+
+	oneDiffers := mustParseGo(t, `package foo
+func Foo() {}
+func bar() {}
+`)
+	if n := countMatches(oneDiffers, q); n != 0 {
+		t.Errorf("one-differs: got %d, want 0", n)
+	}
+}
+
+// @a=["foo","bar"], @b=["foo","bar"] — aligned pairs match (pairwise, not
+// Cartesian: ("foo","bar") across keyed elements would fail).
+func TestEqPredicate_quantifiedCapturePairwise(t *testing.T) {
+	src := `package foo
+
+var _ = map[string]string{
+	"foo": "foo",
+	"bar": "bar",
+}
+`
+	ast := mustParseGo(t, src)
+	q := mustQuery(t, `(literal_value
+		(keyed_element
+			key: (literal_element (interpreted_string_literal) @a)
+			value: (literal_element (interpreted_string_literal) @b))
+		(keyed_element
+			key: (literal_element (interpreted_string_literal) @a)
+			value: (literal_element (interpreted_string_literal) @b))
+		(#eq? @a @b))`)
+
+	var matches int
+	for range ast.Query(q) {
+		matches++
+	}
+	if matches != 1 {
+		t.Errorf("expected 1 match, got %d", matches)
 	}
 }
 


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
