### PR TITLE
fix: allow referencing default library+test names by custom name

### DIFF
--- a/language/js/config.go
+++ b/language/js/config.go
@@ -505,9 +505,18 @@ func (c *JsGazelleConfig) SetTestsNamingLibraryConvention(testsNamingConvention 
 	c.targetNamingOverrides[DefaultTestsName] = testsNamingConvention
 }
 
+func (c *JsGazelleConfig) ReverseMapTargetName(mappedName string) string {
+	for name, override := range c.targetNamingOverrides {
+		if override == mappedName {
+			return name
+		}
+	}
+	return mappedName
+}
+
 func (c *JsGazelleConfig) MapTargetName(name string) string {
-	if c.targetNamingOverrides[name] != "" {
-		return c.targetNamingOverrides[name]
+	if n := c.targetNamingOverrides[name]; n != "" {
+		return n
 	}
 	return name
 }

--- a/language/js/configure.go
+++ b/language/js/configure.go
@@ -124,6 +124,8 @@ func (ts *typeScriptLang) readDirectives(c *config.Config, rel string, f *rule.F
 			if !hasGroup {
 				groupValue = groupName
 				groupName = ""
+			} else {
+				groupName = config.ReverseMapTargetName(groupName)
 			}
 			config.SetTsConfigGenerationEnabled(groupName, strings.TrimSpace(groupValue) == "enabled")
 		case Directive_TypeScriptProtoExtension:
@@ -149,7 +151,7 @@ func (ts *typeScriptLang) readDirectives(c *config.Config, rel string, f *rule.F
 
 			// The first entry may be the group-key, not a label
 			if len(visLabels) > 0 && !(strings.HasPrefix(visLabels[0], ":") || strings.HasPrefix(visLabels[0], "//")) {
-				group = visLabels[0]
+				group = config.ReverseMapTargetName(visLabels[0])
 				visLabels = visLabels[1:]
 			}
 
@@ -166,6 +168,8 @@ func (ts *typeScriptLang) readDirectives(c *config.Config, rel string, f *rule.F
 			if !hasGroup {
 				groupFile = groupName
 				groupName = ""
+			} else {
+				groupName = config.ReverseMapTargetName(groupName)
 			}
 			config.SetTsconfigFile(groupName, strings.TrimSpace(groupFile))
 		case Directive_TypeScriptConfigIgnore:
@@ -174,6 +178,8 @@ func (ts *typeScriptLang) readDirectives(c *config.Config, rel string, f *rule.F
 			if !hasGroup {
 				propName = groupName
 				groupName = ""
+			} else {
+				groupName = config.ReverseMapTargetName(groupName)
 			}
 			config.AddIgnoredTsConfig(groupName, strings.TrimSpace(propName))
 		case Directive_IgnoreImports:
@@ -229,7 +235,7 @@ func (ts *typeScriptLang) readDirectives(c *config.Config, rel string, f *rule.F
 			groupGlob := value
 
 			if before, after, found := strings.Cut(value, " "); found {
-				group = before
+				group = config.ReverseMapTargetName(before)
 				groupGlob = strings.TrimSpace(after)
 			}
 
@@ -239,7 +245,7 @@ func (ts *typeScriptLang) readDirectives(c *config.Config, rel string, f *rule.F
 			groupGlob := value
 
 			if before, after, found := strings.Cut(value, " "); found {
-				group = before
+				group = config.ReverseMapTargetName(before)
 				groupGlob = strings.TrimSpace(after)
 			}
 

--- a/language/js/tests/naming_conventions/BUILD.in
+++ b/language/js/tests/naming_conventions/BUILD.in
@@ -1,0 +1,20 @@
+# Modify naming conventions
+# gazelle:js_project_naming_convention lib
+# gazelle:js_tests_naming_convention lib_tests
+
+# Reference lib+tests via custom naming conventions for file globs
+# gazelle:js_files lib *.ts
+# gazelle:js_test_files lib_tests *.spec.ts
+
+# Reference lib+tests via custom naming conventions for tsconfig
+# gazelle:js_tsconfig_file lib tsconfig.lib.json
+# gazelle:js_tsconfig_file lib_tests tsconfig.tests.json
+
+# Reference default lib via its custom name for visibility
+# gazelle:js_visibility lib //custom:__pkg__
+
+# Reference default lib via its custom name to ignore the reflected declaration_dir attribute
+# gazelle:js_tsconfig_ignore lib declaration_dir
+
+# Reference default tests via its custom name to disable ts_config generation
+# gazelle:js_tsconfig lib_tests disabled

--- a/language/js/tests/naming_conventions/BUILD.out
+++ b/language/js/tests/naming_conventions/BUILD.out
@@ -1,0 +1,43 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+
+# Modify naming conventions
+# gazelle:js_project_naming_convention lib
+# gazelle:js_tests_naming_convention lib_tests
+
+# Reference lib+tests via custom naming conventions for file globs
+# gazelle:js_files lib *.ts
+# gazelle:js_test_files lib_tests *.spec.ts
+
+# Reference lib+tests via custom naming conventions for tsconfig
+# gazelle:js_tsconfig_file lib tsconfig.lib.json
+# gazelle:js_tsconfig_file lib_tests tsconfig.tests.json
+
+# Reference default lib via its custom name for visibility
+# gazelle:js_visibility lib //custom:__pkg__
+
+# Reference default lib via its custom name to ignore the reflected declaration_dir attribute
+# gazelle:js_tsconfig_ignore lib declaration_dir
+
+# Reference default tests via its custom name to disable ts_config generation
+# gazelle:js_tsconfig lib_tests disabled
+
+ts_project(
+    name = "lib",
+    srcs = ["a.ts"],
+    declaration = True,
+    tsconfig = ":tsconfig_lib",
+    visibility = ["//custom:__pkg__"],
+)
+
+ts_project(
+    name = "lib_tests",
+    testonly = True,
+    srcs = ["a.spec.ts"],
+    deps = [":lib"],
+)
+
+ts_config(
+    name = "tsconfig_lib",
+    src = "tsconfig.lib.json",
+    visibility = [":__subpackages__"],
+)

--- a/language/js/tests/naming_conventions/WORKSPACE
+++ b/language/js/tests/naming_conventions/WORKSPACE
@@ -1,0 +1,2 @@
+# This is a Bazel workspace for the Gazelle test data.
+workspace(name = "naming_conventions")

--- a/language/js/tests/naming_conventions/a.spec.ts
+++ b/language/js/tests/naming_conventions/a.spec.ts
@@ -1,0 +1,1 @@
+import "./a.js"

--- a/language/js/tests/naming_conventions/tsconfig.lib.json
+++ b/language/js/tests/naming_conventions/tsconfig.lib.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "declaration": true,
+        "declarationDir": "foo"
+    }
+}

--- a/language/js/tests/naming_conventions/tsconfig.tests.json
+++ b/language/js/tests/naming_conventions/tsconfig.tests.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "outDir": "test-bin"
+    }
+}


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- New test cases added
