### PR TITLE
fix: record all concurrent errors during target generation

### DIFF
--- a/common/BUILD.bazel
+++ b/common/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
 go_test(
     name = "common_test",
     srcs = [
+        "error_test.go",
         "glob_test.go",
         "set_test.go",
     ],
@@ -35,6 +36,7 @@ go_test(
     deps = [
         "@com_github_bazelbuild_buildtools//build",
         "@com_github_bmatcuk_doublestar_v4//:doublestar",
+        "@gazelle//config",
         "@gazelle//label",
     ],
 )

--- a/common/error.go
+++ b/common/error.go
@@ -2,16 +2,45 @@ package gazelle
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"sync"
 
 	BazelLog "github.com/aspect-build/aspect-gazelle/common/logger"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 )
 
-// NOTE: must align with patched/vendored gazelle code injecting context into config.Exts
-const gazelleContextCancelKey = "aspect:context.cancel"
+const (
+	gazelleContextKey             = "aspect:context"
+	gazelleContextCancelKey       = "aspect:context.cancel"
+	gazelleContextCancelErrorsKey = "aspect:context.cancel.errors"
+)
+
+// SetupCancellableContext wraps ctx in a cancel-with-cause context, registers
+// it (and a fresh error accumulator) on c.Exts so GenerationErrorf et al. can
+// route their messages here, and returns the wrapped context.
+func SetupCancellableContext(c *config.Config, ctx context.Context) context.Context {
+	ctx, cancelWithCause := context.WithCancelCause(ctx)
+	c.Exts[gazelleContextKey] = ctx
+	c.Exts[gazelleContextCancelKey] = cancelWithCause
+	c.Exts[gazelleContextCancelErrorsKey] = &errAccumulator{}
+	return ctx
+}
+
+// CheckCancellation returns the joined accumulated errors the first time it
+// observes a cancelled context, and nil on every subsequent call. Returning
+// once prevents downstream collectors (e.g. walk's w.errs) from accumulating
+// duplicate references to the same accumulator and emitting its joined
+// message N times via errors.Join.
+func CheckCancellation(c *config.Config) error {
+	ctx, ok := c.Exts[gazelleContextKey].(context.Context)
+	if !ok || ctx.Err() == nil {
+		return nil
+	}
+	return c.Exts[gazelleContextCancelErrorsKey].(*errAccumulator).surface()
+}
 
 // MisconfiguredErrorf reports a misconfiguration error on the user's part.
 //
@@ -35,11 +64,50 @@ func ImportErrorf(c *config.Config, msg string, args ...any) {
 }
 
 func cancelOrFatal(c *config.Config, msg string, args ...any) {
-	if ctxCancel, ctxExists := c.Exts[gazelleContextCancelKey]; ctxExists {
-		ctxCancel.(context.CancelCauseFunc)(fmt.Errorf(msg, args...))
-		return
+	if acc, ok := c.Exts[gazelleContextCancelErrorsKey].(*errAccumulator); ok {
+		acc.add(fmt.Errorf(msg, args...))
+		if ctxCancel, ctxExists := c.Exts[gazelleContextCancelKey]; ctxExists {
+			ctxCancel.(context.CancelCauseFunc)(acc)
+			return
+		}
 	}
 
 	fmt.Fprintf(os.Stderr, msg, args...)
 	BazelLog.Fatalf(msg, args...)
+}
+
+// errAccumulator is an error that joins every error appended to it; passed as
+// the cancel-cause so context.Cause(ctx) always reflects the up-to-date join.
+type errAccumulator struct {
+	mu       sync.Mutex
+	errs     []error
+	surfaced bool
+}
+
+// add appends err to the join.
+func (a *errAccumulator) add(err error) {
+	a.mu.Lock()
+	a.errs = append(a.errs, err)
+	a.mu.Unlock()
+}
+
+// surface returns the accumulator once, then nil — so walk's w.errs gets a single entry.
+func (a *errAccumulator) surface() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.surfaced || len(a.errs) == 0 {
+		return nil
+	}
+	a.surfaced = true
+	return a
+}
+
+// Error returns the newline-joined messages of every error added so far.
+func (a *errAccumulator) Error() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.errs) == 0 {
+		return ""
+	}
+	return errors.Join(a.errs...).Error()
 }

--- a/common/error_test.go
+++ b/common/error_test.go
@@ -1,0 +1,101 @@
+package gazelle
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+)
+
+func TestSetupCancellableContext_RegistersExts(t *testing.T) {
+	c := config.New()
+	ctx := SetupCancellableContext(c, context.Background())
+
+	if _, ok := c.Exts[gazelleContextKey].(context.Context); !ok {
+		t.Errorf("expected %s to hold a context.Context", gazelleContextKey)
+	}
+	if _, ok := c.Exts[gazelleContextCancelKey].(context.CancelCauseFunc); !ok {
+		t.Errorf("expected %s to hold a context.CancelCauseFunc", gazelleContextCancelKey)
+	}
+	if _, ok := c.Exts[gazelleContextCancelErrorsKey].(*errAccumulator); !ok {
+		t.Errorf("expected %s to hold an *errAccumulator", gazelleContextCancelErrorsKey)
+	}
+	if ctx.Err() != nil {
+		t.Errorf("context should not be cancelled at setup, got %v", ctx.Err())
+	}
+}
+
+func TestCheckCancellation_NilBeforeError(t *testing.T) {
+	c := config.New()
+	SetupCancellableContext(c, context.Background())
+
+	if err := CheckCancellation(c); err != nil {
+		t.Errorf("expected nil before any error, got %v", err)
+	}
+}
+
+func TestGenerationErrorf_CancelsAndReportsMessage(t *testing.T) {
+	c := config.New()
+	ctx := SetupCancellableContext(c, context.Background())
+
+	GenerationErrorf(c, "boom %s", "kaboom")
+
+	if ctx.Err() == nil {
+		t.Fatal("expected context to be cancelled")
+	}
+	err := CheckCancellation(c)
+	if err == nil {
+		t.Fatal("expected non-nil error after cancellation")
+	}
+	if got := err.Error(); !strings.Contains(got, "boom kaboom") {
+		t.Errorf("expected message to contain %q, got %q", "boom kaboom", got)
+	}
+}
+
+func TestGenerationErrorf_JoinsMultipleErrors(t *testing.T) {
+	c := config.New()
+	SetupCancellableContext(c, context.Background())
+
+	GenerationErrorf(c, "first")
+	GenerationErrorf(c, "second")
+	GenerationErrorf(c, "third")
+
+	err := CheckCancellation(c)
+	if err == nil {
+		t.Fatal("expected non-nil error after cancellation")
+	}
+	got := err.Error()
+	for _, want := range []string{"first", "second", "third"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected joined message to contain %q, got %q", want, got)
+		}
+	}
+}
+
+func TestCheckCancellation_SurfacesOnlyOnce(t *testing.T) {
+	c := config.New()
+	SetupCancellableContext(c, context.Background())
+	GenerationErrorf(c, "x")
+
+	if err := CheckCancellation(c); err == nil {
+		t.Fatal("first call should return the accumulator")
+	}
+	if err := CheckCancellation(c); err != nil {
+		t.Errorf("second call should return nil, got %v", err)
+	}
+}
+
+func TestContextCause_TracksLateAdditions(t *testing.T) {
+	c := config.New()
+	ctx := SetupCancellableContext(c, context.Background())
+
+	GenerationErrorf(c, "early")
+	cause := context.Cause(ctx)
+	GenerationErrorf(c, "late")
+
+	got := cause.Error()
+	if !strings.Contains(got, "early") || !strings.Contains(got, "late") {
+		t.Errorf("expected cause to reflect both errors, got %q", got)
+	}
+}

--- a/runner/vendored/gazelle/BUILD.bazel
+++ b/runner/vendored/gazelle/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//vendored/gazelle/internal/wspace",
+        "@aspect_gazelle//common",
         "@com_github_bazelbuild_buildtools//build",
         "@com_github_pmezard_go_difflib//difflib",
         "@gazelle//config",

--- a/runner/vendored/gazelle/fix-update.go
+++ b/runner/vendored/gazelle/fix-update.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/bazelbuild/buildtools/build"
 
+	common "github.com/aspect-build/aspect-gazelle/common"
 	"github.com/aspect-build/aspect-gazelle/runner/vendored/gazelle/internal/wspace"
 	"github.com/bazelbuild/bazel-gazelle/config"
 	gzflag "github.com/bazelbuild/bazel-gazelle/flag"
@@ -263,15 +264,6 @@ var genericLoads = []rule.LoadInfo{
 	},
 }
 
-// NOTE: additional aspect-gazelle context.Context
-func checkCancellation(c *config.Config) error {
-	ctx := c.Exts["aspect:context"].(context.Context)
-	if ctx.Err() != nil {
-		return context.Cause(ctx)
-	}
-	return nil
-}
-
 // NOTE: additional aspect-cli update result status
 type fixUpdateStatus struct {
 	visited int
@@ -345,9 +337,7 @@ func runFixUpdate(wd string, languages []language.Language, cmd command, args []
 	}
 
 	// NOTE: additional aspect-gazelle context
-	ctx, cancelWithCause := context.WithCancelCause(ctx)
-	c.Exts["aspect:context"] = ctx
-	c.Exts["aspect:context.cancel"] = cancelWithCause
+	ctx = common.SetupCancellableContext(c, ctx)
 
 	// Visit all directories in the repository.
 	var visits []visitRecord
@@ -417,7 +407,7 @@ func runFixUpdate(wd string, languages []language.Language, cmd command, args []
 			}
 
 			// NOTE: additional aspect-gazelle context
-			if err := checkCancellation(c); err != nil {
+			if err := common.CheckCancellation(c); err != nil {
 				return walk.Walk2FuncResult{Err: err}
 			}
 		}
@@ -556,7 +546,7 @@ func runFixUpdate(wd string, languages []language.Language, cmd command, args []
 				rslv.Resolve(v.c, ruleIndex, rc, r, v.imports[i], from)
 
 				// NOTE: additional aspect-gazelle context
-				if err := checkCancellation(c); err != nil {
+				if err := common.CheckCancellation(c); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
