### PR TITLE
fix: walk full ancestor chain for group-specific tsconfig before falling back to default

### DIFF
--- a/language/js/tests/tsconfig_multiple_configs/custom_names/src/BUILD.out
+++ b/language/js/tests/tsconfig_multiple_configs/custom_names/src/BUILD.out
@@ -13,7 +13,7 @@ ts_project(
     testonly = True,
     srcs = ["app.spec.ts"],
     composite = True,
-    tsconfig = "//custom_names:tsconfig_lib",
+    tsconfig = "//:tsconfig_test",
     deps = [
         ":src_lib",
         "//:node_modules/tslib",

--- a/language/js/tests/tsconfig_multiple_configs/with_rootdir/lib/BUILD.out
+++ b/language/js/tests/tsconfig_multiple_configs/with_rootdir/lib/BUILD.out
@@ -13,7 +13,7 @@ ts_project(
     testonly = True,
     srcs = ["util.spec.ts"],
     composite = True,
-    tsconfig = "//with_rootdir:tsconfig_lib",
+    tsconfig = "//:tsconfig_test",
     deps = [
         ":lib",
         "//:node_modules/tslib",

--- a/language/js/typescript/config.go
+++ b/language/js/typescript/config.go
@@ -149,20 +149,30 @@ func (tc *TsWorkspace) tsConfigResolver(dir, rel string) []string {
 }
 
 func (tc *TsWorkspace) FindConfig(dir, groupName string) (string, *TsConfig) {
+	// The closest default in case no group config is found
+	var defaultRel string
+	var defaultConfig *TsConfig
+
 	for {
 		if dir == "." {
 			dir = ""
 		}
 
+		// Return the first group config found
 		if groupName != "" {
 			if c := tc.GetTsConfigFile(dir, groupName); c != nil {
 				return dir, c
 			}
 		}
 
-		// Fall back to the default group config if a group-specific one isn't found.
-		if c := tc.GetTsConfigFile(dir, ""); c != nil {
-			return dir, c
+		// Record the default group config as a fallback in case no group config is found
+		if defaultConfig == nil {
+			if c := tc.GetTsConfigFile(dir, ""); c != nil {
+				defaultRel, defaultConfig = dir, c
+				if groupName == "" {
+					return defaultRel, defaultConfig
+				}
+			}
 		}
 
 		if dir == "" {
@@ -173,7 +183,7 @@ func (tc *TsWorkspace) FindConfig(dir, groupName string) (string, *TsConfig) {
 		dir = strings.TrimSuffix(dir, "/")
 	}
 
-	return "", nil
+	return defaultRel, defaultConfig
 }
 
 func (tc *TsWorkspace) ExpandPaths(from, f, groupName string) []string {


### PR DESCRIPTION
A target requesting a group-specific tsconfig (e.g. `{dirname}_tests tsconfig.test.json`) previously fell back to the *closest* default tsconfig.json found while walking the chain, even when an ancestor declared the group-specific config. Split FindConfig into two passes: walk the chain once for the requested group, then fall back to the default group only if no group-specific config exists anywhere up the tree.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Covered by existing test cases
- New test cases added
