### PR TITLE
refactor(ibp): use nil sources to signal fresh-instance reset on CYCLE messages

### DIFF
--- a/runner/pkg/ibp/client.go
+++ b/runner/pkg/ibp/client.go
@@ -213,14 +213,19 @@ func convertWireCycle(msg map[string]any) (CycleSourcesMessage, error) {
 
 	cycleId := int(cycleIdFloat)
 
-	sources := make(SourceInfoMap, len(msg["sources"].(map[string]any)))
-	for k, v := range msg["sources"].(map[string]any) {
-		if v == nil {
-			sources[k] = nil
-		} else {
-			sources[k] = &SourceInfo{
-				IsSymlink: readOptionalBool(v.(map[string]any), "is_symlink"),
-				IsSource:  readOptionalBool(v.(map[string]any), "is_source"),
+	// `sources: null` (or absent / non-object) is the fresh-instance reset
+	// signal — leaves sources nil. `sources: {...}` is a delta.
+	var sources SourceInfoMap
+	if rawSources, ok := msg["sources"].(map[string]any); ok {
+		sources = make(SourceInfoMap, len(rawSources))
+		for k, v := range rawSources {
+			if v == nil {
+				sources[k] = nil
+			} else {
+				sources[k] = &SourceInfo{
+					IsSymlink: readOptionalBool(v.(map[string]any), "is_symlink"),
+					IsSource:  readOptionalBool(v.(map[string]any), "is_source"),
+				}
 			}
 		}
 	}

--- a/runner/pkg/ibp/client_test.go
+++ b/runner/pkg/ibp/client_test.go
@@ -124,4 +124,23 @@ func TestConvertWireCycle_MissingOptionalFieldsDefaultsToEmpty(t *testing.T) {
 	if cycle.TraceId != "" || cycle.SpanId != "" {
 		t.Fatalf("expected empty trace/span for non-string input, got trace=%q span=%q", cycle.TraceId, cycle.SpanId)
 	}
+	if cycle.Sources == nil {
+		t.Fatalf("expected non-nil Sources for empty-map delta, got nil")
+	}
+}
+
+func TestConvertWireCycle_NullSourcesIsFreshInstanceSignal(t *testing.T) {
+	msg := map[string]any{
+		"kind":     "CYCLE",
+		"cycle_id": float64(1),
+		"sources":  nil,
+	}
+
+	cycle, err := convertWireCycle(msg)
+	if err != nil {
+		t.Fatalf("convertWireCycle returned error: %v", err)
+	}
+	if cycle.Sources != nil {
+		t.Fatalf("expected nil Sources for fresh-instance signal, got %#v", cycle.Sources)
+	}
 }

--- a/runner/pkg/ibp/protocol.go
+++ b/runner/pkg/ibp/protocol.go
@@ -319,7 +319,11 @@ func (p *aspectBazelProtocol) Init(ctx context.Context, scope WatchScope, source
 func (p *aspectBazelProtocol) Cycle(ctx context.Context, scope WatchScope, changes SourceInfoMap) error {
 	cycle_id := int(p.cycle_id.Add(1))
 
-	fmt.Printf("%s Sending cycle #%v (%v changes) to %s\n", color.GreenString("INFO:"), cycle_id, len(changes), p.socketPath)
+	if changes == nil {
+		fmt.Printf("%s Sending cycle #%v (fresh-instance reset) to %s\n", color.GreenString("INFO:"), cycle_id, p.socketPath)
+	} else {
+		fmt.Printf("%s Sending cycle #%v (%v changes) to %s\n", color.GreenString("INFO:"), cycle_id, len(changes), p.socketPath)
+	}
 
 	// Support: Protocol0 did not have the concept of scope so remove it from the message if
 	// the connection does not support it to maintain compatibility with older clients.

--- a/runner/pkg/ibp/protocol_test.go
+++ b/runner/pkg/ibp/protocol_test.go
@@ -1,7 +1,9 @@
 package ibp
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 
 	"go.opentelemetry.io/otel/trace"
@@ -246,5 +248,54 @@ func TestCycle_V1KeepsScope(t *testing.T) {
 	}
 	if msg.Scope != WatchScope_Sources {
 		t.Fatalf("expected sources scope for v1 protocol, got %q", msg.Scope)
+	}
+	if msg.Sources == nil {
+		t.Fatalf("expected non-nil Sources for delta cycle, got nil")
+	}
+}
+
+func TestCycle_NilSourcesSignalsFreshInstance(t *testing.T) {
+	socket := &fakeServerSocket{
+		recvQueue: []map[string]any{
+			{
+				"kind":     "CYCLE_COMPLETED",
+				"cycle_id": float64(1),
+			},
+		},
+	}
+	p := &aspectBazelProtocol{
+		socket:           socket,
+		socketPath:       "test.sock",
+		connectedVersion: VERSION_1,
+	}
+
+	if err := p.Cycle(context.Background(), WatchScope_Sources, nil); err != nil {
+		t.Fatalf("Cycle returned error: %v", err)
+	}
+
+	msg, ok := socket.sent[0].(CycleSourcesMessage)
+	if !ok {
+		t.Fatalf("expected CycleSourcesMessage, got %T", socket.sent[0])
+	}
+	if msg.Sources != nil {
+		t.Fatalf("expected nil Sources to propagate to wire message, got %#v", msg.Sources)
+	}
+}
+
+func TestCycle_NilSourcesSerializesToJSONNull(t *testing.T) {
+	msg := CycleSourcesMessage{
+		CycleMessage: CycleMessage{
+			Message: Message{Kind: "CYCLE"},
+			CycleId: 1,
+		},
+		Scope:   WatchScope_Sources,
+		Sources: nil,
+	}
+	b, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal returned error: %v", err)
+	}
+	if !bytes.Contains(b, []byte(`"sources":null`)) {
+		t.Fatalf("expected sources to serialize as null, got %s", b)
 	}
 }


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
