### PR TITLE
fix(runner): invalidate walk cache on root-level file changes

### DIFF
--- a/runner/BUILD.bazel
+++ b/runner/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@gazelle//:def.bzl", "gazelle")
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 load("//:def.bzl", "aspect_gazelle")
 
 # Use the gazelle bazel modules instead of go.mod modules
@@ -93,4 +93,10 @@ bzl_library(
     srcs = ["def.bzl"],
     visibility = ["//visibility:public"],
     deps = ["//:rules"],
+)
+
+go_test(
+    name = "runner_test",
+    srcs = ["runner_test.go"],
+    embed = [":runner"],
 )

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -415,6 +415,11 @@ func (i *walkCacheInvalidator) Configure(c *config.Config, rel string, f *rule.F
 
 func walkCacheEntryInvalidated(rel string, dirs []string) bool {
 	for _, d := range dirs {
+		// A change at the root invalidates every entry.
+		// Support "." returned by path.Dir() in addition to standard ""
+		if d == "." || d == "" {
+			return true
+		}
 		if rel == d {
 			return true
 		}

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -1,0 +1,87 @@
+package runner
+
+import "testing"
+
+func TestWalkCacheEntryInvalidated(t *testing.T) {
+	cases := []struct {
+		name string
+		rel  string
+		dirs []string
+		want bool
+	}{
+		{
+			name: "no invalidated dirs",
+			rel:  "pkg",
+			dirs: nil,
+			want: false,
+		},
+		{
+			name: "exact match",
+			rel:  "pkg/sub",
+			dirs: []string{"pkg/sub"},
+			want: true,
+		},
+		{
+			name: "descendant of invalidated dir",
+			rel:  "pkg/sub/leaf",
+			dirs: []string{"pkg/sub"},
+			want: true,
+		},
+		{
+			name: "unrelated dir",
+			rel:  "other",
+			dirs: []string{"pkg"},
+			want: false,
+		},
+		// Guards against the "pkg" prefix accidentally matching "pkg-foo": the '/' check
+		// in the predicate is the reason this returns false.
+		{
+			name: "prefix-but-not-descendant",
+			rel:  "pkg-foo",
+			dirs: []string{"pkg"},
+			want: false,
+		},
+		// Root-change cases: path.Dir returns "." for files at the workspace root,
+		// but the gazelle walk cache keys the root entry as "". Both must invalidate
+		// every entry, matching invalidateWalkCache in pkg/watchman/cache.go.
+		{
+			name: "root dot invalidates root entry",
+			rel:  "",
+			dirs: []string{"."},
+			want: true,
+		},
+		{
+			name: "root dot invalidates nested entry",
+			rel:  "pkg/sub",
+			dirs: []string{"."},
+			want: true,
+		},
+		{
+			name: "root empty invalidates root entry",
+			rel:  "",
+			dirs: []string{""},
+			want: true,
+		},
+		{
+			name: "root empty invalidates nested entry",
+			rel:  "pkg/sub",
+			dirs: []string{""},
+			want: true,
+		},
+		{
+			name: "any matching dir wins",
+			rel:  "pkg/sub",
+			dirs: []string{"other", "pkg/sub", "more"},
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := walkCacheEntryInvalidated(tc.rel, tc.dirs)
+			if got != tc.want {
+				t.Errorf("walkCacheEntryInvalidated(%q, %v) = %v, want %v", tc.rel, tc.dirs, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- New test cases added
