### PR TITLE
fix: add yaml alias support

### DIFF
--- a/language/orion/queries/yq.go
+++ b/language/orion/queries/yq.go
@@ -76,6 +76,8 @@ func convertYqNodeToValue(node *yqlib.CandidateNode) interface{} {
 			s = append(s, convertYqNodeToValue(n))
 		}
 		return s
+	case yqlib.AliasNode:
+		return convertYqNodeToValue(node.Alias)
 	case yqlib.ScalarNode:
 		val, err := node.GetValueRep()
 		if err != nil {

--- a/language/orion/tests/starzelle/query-yaml/b.yaml
+++ b/language/orion/tests/starzelle/query-yaml/b.yaml
@@ -1,3 +1,4 @@
+lib_name: &lib_name lib/l
 imports:
-  - lib/l
+  - *lib_name
 testonly: false


### PR DESCRIPTION
With this change we now support anchors in Yaml for aliases

While testing Orion for some internal project I was getting ```2026/05/11 14:26:15 Unknown yq node kind: 8```, when
our Yaml file looks like:
```yaml
...
version: &VERSION 0.1
source:
  - git+https://github.com/bookingcom/bazeldnf.git#*VERSION
...
```

After looking at the yq code the fix was trivial to figure out.

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- New test cases added
