### PR TITLE
refactor: index orion plugin symbol database by id

### DIFF
--- a/language/orion/plugin/database.go
+++ b/language/orion/plugin/database.go
@@ -5,17 +5,28 @@ import "sync"
 // TODO: move to its own package
 
 type Database struct {
-	Symbols []TargetSymbol
+	symbols map[string][]TargetSymbol
 
-	symbolMutex sync.Mutex
+	mu sync.RWMutex
 }
 
 func (d *Database) AddSymbol(label Label, symbol Symbol) {
-	d.symbolMutex.Lock()
-	defer d.symbolMutex.Unlock()
+	d.mu.Lock()
+	defer d.mu.Unlock()
 
-	d.Symbols = append(d.Symbols, TargetSymbol{
+	if d.symbols == nil {
+		d.symbols = make(map[string][]TargetSymbol)
+	}
+	d.symbols[symbol.Id] = append(d.symbols[symbol.Id], TargetSymbol{
 		Symbol: symbol,
 		Label:  label,
 	})
+}
+
+// LookupSymbols returns all symbols registered with the given id.
+func (d *Database) LookupSymbols(id string) []TargetSymbol {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.symbols[id]
 }

--- a/language/orion/resolver.go
+++ b/language/orion/resolver.go
@@ -269,18 +269,16 @@ func (host *GazelleHost) resolveImport(
 	// }
 
 	// Lookup symbols across plugins in the symbol db
-	for _, symbol := range host.database.Symbols {
-		// TODO: only match correct "providers"
-
-		if importSpec.Imp == symbol.Symbol.Id {
-			l := label.Label{
-				Repo:     symbol.Label.Repo,
-				Pkg:      symbol.Label.Pkg,
-				Name:     symbol.Label.Name,
-				Relative: false,
-			}
-			return Resolution_Label, &l, nil
+	// TODO: only match correct "providers"; ambiguity handling
+	if symbols := host.database.LookupSymbols(impt.Id); len(symbols) > 0 {
+		s := symbols[0]
+		l := label.Label{
+			Repo:     s.Label.Repo,
+			Pkg:      s.Label.Pkg,
+			Name:     s.Label.Name,
+			Relative: false,
 		}
+		return Resolution_Label, &l, nil
 	}
 
 	return Resolution_NotFound, nil, nil


### PR DESCRIPTION
Replace the linear Database.Symbols slice with a map keyed by symbol id and expose LookupSymbols. Resolver call site is updated mechanically; behavior is unchanged. Switches the mutex to sync.RWMutex since lookups are read-only.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
