### PR TITLE
test: add JS parser test coverage

### DIFF
--- a/common/treesitter/filters_test.go
+++ b/common/treesitter/filters_test.go
@@ -351,3 +351,14 @@ func Foo() {}
 		t.Errorf("expected parameter list to win, got %q", got[0]["item"])
 	}
 }
+
+func TestGetQuery_unknownNodeErrorCompatibility(t *testing.T) {
+	_, err := treesitter.GetQuery(goLang, `(import_ statement ( @foo`)
+	if err == nil {
+		t.Fatal("expected query error")
+	}
+	want := "invalid node type 'import_' at line 1 column 0"
+	if err.Error() != want {
+		t.Fatalf("got %q, want %q", err.Error(), want)
+	}
+}

--- a/language/js/parser/parser_test.go
+++ b/language/js/parser/parser_test.go
@@ -82,6 +82,16 @@ var testCases = []struct {
 		desc:     "incorrect imports",
 		ts:       `@import "~mapbox.js/dist/mapbox.css";`,
 		filename: "actuallyScss.ts",
+	}, {
+		desc: "triple slash directives are top-level only",
+		ts: `/// <reference types="node" />
+
+			function f() {
+				/// <reference types="jest" />
+			}
+		`,
+		filename:        "triple-slash.ts",
+		expectedImports: []string{"node"},
 	},
 	{
 		desc: "ignores commented out imports",
@@ -239,6 +249,25 @@ var testCases = []struct {
 		`,
 		filename:        "types.ts",
 		expectedImports: []string{"react", "y"},
+	},
+	{
+		desc: "dynamic type import forms",
+		ts: `
+			function x<T>(a: typeof import('jquery')): T {
+				return a as T;
+			}
+			export const F: typeof import('@aspect-test/a') = null as any
+			const f = (x<typeof import('@aspect-test/b')>)(null)
+			const g = (null as any) as typeof import('@aspect-test/c')
+			(function() {
+				return [...(await x<typeof import("@aspect-test/d")>())]
+			})()
+			new Set<typeof import('@aspect-test/e')>()
+			export type * as Foo from '@aspect-test/f'
+			import type * as Bar from '@aspect-test/g'
+		`,
+		filename:        "dynamic-type-imports.ts",
+		expectedImports: []string{"jquery", "@aspect-test/a", "@aspect-test/b", "@aspect-test/c", "@aspect-test/d", "@aspect-test/e", "@aspect-test/f", "@aspect-test/g"},
 	},
 	{
 		desc: "include imports only used as types",


### PR DESCRIPTION
Cherry-picked test additions from #313:
- Cover triple-slash directive scoping and dynamic type-import forms in language/js/parser/parser_test.go.

### Changes are visible to end-users: no

### Test plan

- New test cases added
