### PR TITLE
refactor: modify rust llvm from glibc to musl

### DIFF
--- a/language/js/MODULE.bazel
+++ b/language/js/MODULE.bazel
@@ -35,8 +35,10 @@ rust_crate.from_cargo(
     platform_triples = [
         "aarch64-apple-darwin",
         "aarch64-unknown-linux-gnu",
+        "aarch64-unknown-linux-musl",
         "x86_64-apple-darwin",
         "x86_64-unknown-linux-gnu",
+        "x86_64-unknown-linux-musl",
     ],
 )
 use_repo(rust_crate, "aspect_js_parser_crates")
@@ -48,8 +50,7 @@ use_repo(rust_crate, "aspect_js_parser_crates")
 bazel_dep(name = "llvm", version = "0.7.7")
 
 # Direct dep so `@platforms` and `@llvm//constraints/...` are visible by their
-# apparent names in //platform:local_gnu (referenced by consumers as the host
-# platform on Linux).
+# apparent names in the //platform definitions.
 bazel_dep(name = "platforms", version = "1.0.0")
 
 register_toolchains("@llvm//toolchain:all")

--- a/language/js/platform/BUILD.bazel
+++ b/language/js/platform/BUILD.bazel
@@ -1,11 +1,16 @@
 # Platforms for compiling the gazelle binary (and its cgo-linked Rust JS parser,
-# //crates/js-parser) from source. Building the Rust parser requires the target
-# platform to carry @llvm//constraints/libc:gnu.2.28: rules_rs's Linux Rust
-# toolchains pin it via target_compatible_with, and without it resolution fails
-# with "No matching toolchains found".
+# //crates/js-parser) from source.
+#
+# local_gnu is the glibc host/build platform (selected on Linux via
+# --host_platform in tools/rust.bazelrc). It's also the exec platform when
+# cross-building the distribution binaries, so the build tools that run there
+# (rustc, proc-macro cdylibs) stay on glibc/PIE -- the musl Rust toolchain forces
+# pie:off, and proc-macro cdylibs need PIE, so exec can't be musl.
+#
+# The linux_* distribution platforms target musl (static, portable across any
+# Linux incl. Alpine, no glibc version floor); darwin_* stay native.
 
-# Glibc host platform for local builds and tests, selected on Linux via
-# --host_platform (tools/rust.bazelrc).
+# Carries gnu.2.28 so the LLVM C/C++ and rules_rs Rust toolchains resolve.
 platform(
     name = "local_gnu",
     constraint_values = ["@llvm//constraints/libc:gnu.2.28"],
@@ -13,14 +18,16 @@ platform(
     visibility = ["//visibility:public"],
 )
 
-# Cross-compilation targets, one per OS/CPU, for producing the pre-compiled
-# distribution binaries. They extend rules_go's <os>_<cpu>_cgo platforms; the
-# Linux ones add the libc:gnu.2.28 constraint :local_gnu needs, while macOS Rust
-# toolchains need none and just inherit the rules_go platform.
+# Linux distribution targets, one per CPU: static musl. They extend rules_go's
+# linux_<cpu>_cgo platforms (inheriting os/cpu/cgo_on) and add the libc:musl +
+# pie:off constraints the rules_rs musl Rust toolchain requires via target_compatible_with.
 [
     platform(
         name = "linux_%s" % cpu,
-        constraint_values = ["@llvm//constraints/libc:gnu.2.28"],
+        constraint_values = [
+            "@llvm//constraints/libc:musl",
+            "@llvm//constraints/pie:off",
+        ],
         parents = ["@rules_go//go/toolchain:linux_%s_cgo" % cpu],
         visibility = ["//visibility:public"],
     )
@@ -30,6 +37,7 @@ platform(
     ]
 ]
 
+# macOS distribution targets: native cgo, no libc constraint needed.
 [
     platform(
         name = "darwin_%s" % cpu,

--- a/runner/bin/gazelle/BUILD.bazel
+++ b/runner/bin/gazelle/BUILD.bazel
@@ -24,6 +24,13 @@ go_library(
 go_binary(
     name = "gazelle",
     embed = [":gazelle_lib"],
+    # Static-link only when built for a musl platform (the Linux release
+    # binaries). gc_linkopts is per-target, so -static can't leak to the glibc
+    # exec build tools the way rules_go's go/config:static would; default empty.
+    gc_linkopts = select({
+        "@llvm//constraints/libc:musl": ["-extldflags=-static"],
+        "//conditions:default": [],
+    }),
     tags = ["supports_incremental_build_protocol"],
     visibility = ["//visibility:public"],
 )

--- a/tools/rust.bazelrc
+++ b/tools/rust.bazelrc
@@ -36,4 +36,8 @@ common --experimental_platform_in_output_dir
 # On Linux, select a host platform carrying @llvm//constraints/libc:gnu.2.28 so
 # rules_rs's Linux Rust toolchains resolve; the default host platform lacks the
 # libc constraint and resolution fails with "No matching toolchains found".
+#
+# This glibc host is also the exec platform for the musl release cross-builds;
+# the musl distribution targets live in @aspect_gazelle_js//platform (which
+# explains why exec must stay glibc).
 common:linux --host_platform=@aspect_gazelle_js//platform:local_gnu


### PR DESCRIPTION
### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Linux prebuilt binaries are now statically linked against musl, so they run on any Linux (including Alpine and older glibc) with no glibc version floor. macOS binaries are unchanged.

### Test plan

- Covered by existing test cases
