### PR TITLE
perf: build the oxc JS/TS parser at opt-level 3

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -29,6 +29,7 @@ mkdir -p artifacts
 for platform in "${PLATFORMS[@]}"; do
 	(cd runner && bazel run \
 		--run_under cp \
+		-c opt \
 		"//:gazelle_prebuilt_bin.${platform}" \
 		"$PWD/../artifacts/aspect_gazelle-${platform}")
 done

--- a/language/js/MODULE.bazel
+++ b/language/js/MODULE.bazel
@@ -7,6 +7,7 @@ bazel_dep(name = "bazel_lib", version = "3.0.0")
 bazel_dep(name = "rules_go", version = "0.60.0")
 bazel_dep(name = "rules_rs", version = "0.0.73")
 bazel_dep(name = "gazelle", version = "0.51.0")  # must match go.mod
+bazel_dep(name = "with_cfg.bzl", version = "0.14.6")
 
 # Go modules
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")

--- a/language/js/crates/js-parser/BUILD.bazel
+++ b/language/js/crates/js-parser/BUILD.bazel
@@ -1,26 +1,44 @@
 load("@rules_rs//rs:rust_static_library.bzl", "rust_static_library")
 load("@rules_rs//rs:rust_test.bzl", "rust_test")
+load(":opt.bzl", "opt_rust_static_library")
 
-# Static library exposing the C ABI js_parser_parse / js_parser_free.
-# Provides CcInfo so it can be passed directly as `cdeps` on the go_library
-# in //parser. See parser/parser.go.
-rust_static_library(
+_SRCS = ["src/lib.rs"]
+
+_DEPS = [
+    "@aspect_js_parser_crates//:oxc_allocator",
+    "@aspect_js_parser_crates//:oxc_ast",
+    "@aspect_js_parser_crates//:oxc_ast_visit",
+    "@aspect_js_parser_crates//:oxc_parser",
+    "@aspect_js_parser_crates//:oxc_span",
+    "@aspect_js_parser_crates//:regex",
+]
+
+# Static library exposing the C ABI js_parser_parse / js_parser_free. opt.bzl
+# pins it to opt-level 3 for every consumer (the prebuilt release further builds
+# with -c opt, optimizing the Go side and stripping the final binary). Provides
+# CcInfo so it can be passed as `cdeps` on the go_library in //parser. See
+# parser/parser.go.
+opt_rust_static_library(
     name = "js-parser",
-    srcs = ["src/lib.rs"],
+    srcs = _SRCS,
     edition = "2021",
     visibility = ["//parser:__pkg__"],
-    deps = [
-        "@aspect_js_parser_crates//:oxc_allocator",
-        "@aspect_js_parser_crates//:oxc_ast",
-        "@aspect_js_parser_crates//:oxc_ast_visit",
-        "@aspect_js_parser_crates//:oxc_parser",
-        "@aspect_js_parser_crates//:oxc_span",
-        "@aspect_js_parser_crates//:regex",
-    ],
+    deps = _DEPS,
+)
+
+# Plain build of the same crate for the unit test. rust_test can't consume the
+# opt :js-parser directly (the with_cfg wrapper doesn't forward the crate-info
+# provider rust_test needs), and an opt+LTO test build would only be slower.
+# srcs/deps are shared via the constants above, so this isn't duplication.
+rust_static_library(
+    name = "js-parser_testlib",
+    srcs = _SRCS,
+    edition = "2021",
+    deps = _DEPS,
 )
 
 rust_test(
     name = "js-parser_test",
-    crate = ":js-parser",
+    crate = ":js-parser_testlib",
     edition = "2021",
 )

--- a/language/js/crates/js-parser/opt.bzl
+++ b/language/js/crates/js-parser/opt.bzl
@@ -1,0 +1,23 @@
+"""Always-opt rust_static_library wrapper for the cgo-linked JS parser.
+
+`with_cfg` pins compilation_mode=opt on this target's subtree -- the crate plus
+the oxc deps where parse time actually goes -- so the parser is built at
+opt-level 3 no matter the consumer's build mode. That matters when
+aspect_gazelle_js is used as a source bazel_dep inside someone's
+`gazelle_binary(languages = [...])`: their `bazel run //:gazelle` is fastbuild
+and we can't rely on `-c opt`, but they still get an optimized parser.
+
+opt-level 3 is the bulk of the win, so it's all we pin here. We deliberately skip
+LTO and codegen-units=1: LTO's gain over opt-level 3 is marginal and its cold
+build cost is high (aspect-cli skips it too). The prebuilt release additionally
+builds with `-c opt`, which optimizes the Go side and strips the final binary.
+"""
+
+load("@rules_rs//rs:rust_static_library.bzl", "rust_static_library")
+load("@with_cfg.bzl", "with_cfg")
+
+opt_rust_static_library, _opt_rust_static_library_rule = (
+    with_cfg(rust_static_library)
+        .set("compilation_mode", "opt")
+        .build()
+)


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
