### PR TITLE
fix: open BCR PR from aspect-forks fork

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,7 +25,7 @@ jobs:
     with:
       tag_name: ${{ inputs.tag_name }}
       tag_prefix: ${{ inputs.tag_prefix }}
-      registry_fork: "aspect-build/bazel-central-registry"
+      registry_fork: "aspect-forks/bazel-central-registry"
       draft: false
       # Open the BCR PR from the caller workflow after the release is finalized,
       # so BCR's unauthenticated presubmit doesn't 404 on the still-draft archive.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,7 +100,7 @@ jobs:
               --method POST \
               -f "title=${MODULE}@${VERSION}" \
               -f "body=${BODY}" \
-              -f "head=aspect-build:${BRANCH}" \
+              -f "head=aspect-forks:${BRANCH}" \
               -f "base=main" \
               -F "maintainer_can_modify=true" \
               -F "draft=false" \


### PR DESCRIPTION
The open-bcr-pr step opened the BCR pull request with `head=aspect-build:<branch>`, but GitHub rejects that fork as a cross-fork PR head (422 head: invalid) — the upstream BCR repo cannot resolve `aspect-build:<branch>` as an openable head even though the branch and its objects are present.

publish-to-bcr's GitHub App pushes the entry branch to its installed fork, aspect-forks/bazel-central-registry, which is the head every previously-successful release PR used. Point both the registry_fork input and the open-bcr-pr head at aspect-forks so they agree with the fork GitHub actually accepts.

### Changes are visible to end-users: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:
