### PR TITLE
chore: split --config=release test into isolated ci job

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -142,10 +142,20 @@ jobs:
           aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Test (runner)
         working-directory: runner
-        run: |
-          aspect test --task-key=test-runner -- //...
-          # Simulate the release_prep.sh build so opt-only failures surface in CI.
-          aspect test --task-key=test-runner-opt --bazel-flag=--config=release -- //:prebuilt_platforms_build_test
+        run: aspect test --task-key=test-runner -- //...
+  # Simulate the release_prep.sh build so opt-only cross-compile failures surface
+  # in CI. Runs concurrently with test-runner against prebuilt_platforms_build_test,
+  # which is tagged "manual" and so excluded from test-runner's //... pattern.
+  test-runner-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
+        with:
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
+      - name: Test (runner, --config=release)
+        working-directory: runner
+        run: aspect test --task-key=test-runner-opt --bazel-flag=--config=release -- //:prebuilt_platforms_build_test
   gazelle-runner-e2e-bin:
     runs-on: ubuntu-latest
     steps:

--- a/runner/BUILD.bazel
+++ b/runner/BUILD.bazel
@@ -73,7 +73,7 @@ alias(
 # output paths differ from the native build's and don't collide. macOS has no
 # such distinguishing constraint, so its host-arch darwin cross would conflict.
 #
-# Tagged "manual" so to avoid cross-compiling except when explicitly run on CI.
+# Tagged "manual" to avoid cross-compiling except when explicitly run on CI.
 build_test(
     name = "prebuilt_platforms_build_test",
     tags = ["manual"],

--- a/runner/BUILD.bazel
+++ b/runner/BUILD.bazel
@@ -65,15 +65,18 @@ alias(
     ]
 ]
 
-# Build every release platform in regular CI so a broken cross-compile fails here
+# Build every release platform in CI so a broken cross-compile fails here
 # instead of only at release time. Gated to Linux, which cross-compiles all four
 # at release time so its coverage matches publish time. It is also the only
 # conflict-free host: the linux_* cross platforms carry libc:musl + pie:off
 # constraints distinct from the glibc/PIE Linux host, so their @llvm compiler-rt
 # output paths differ from the native build's and don't collide. macOS has no
 # such distinguishing constraint, so its host-arch darwin cross would conflict.
+#
+# Tagged "manual" so to avoid cross-compiling except when explicitly run on CI.
 build_test(
     name = "prebuilt_platforms_build_test",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     targets = [
         ":gazelle_prebuilt_bin.linux_amd64",


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
