### PR TITLE
chore: drop .bazelversion files from releases

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -48,9 +48,9 @@ if [[ -n "$SRC_MODULE_ROOT" ]]; then
 	# self-contained .bazelrc), so drop it from the published archive.
 	rm -f "${UNPACK_DIR}/${PREFIX}/.bazelrc"
 
-	# .bazelversion is often a symlink to the repo-root file (e.g. ../../.bazelversion,)
-	# out of the hoisted subtree, so those symlinks dangle in the archive. Drop them: a
-	# consumed module's .bazelversion is ignored, and BCR presubmit controls the
+	# .bazelversion is often a symlink to the repo-root file (e.g., ../../.bazelversion)
+	# outside of the hoisted subtree, so those symlinks dangle in the archive. Drop them:
+	# a consumed module's .bazelversion is ignored, and BCR presubmit controls the
 	# bazel version for the bcr_test_module under e2e/smoke.
 	find "${UNPACK_DIR}/${PREFIX}" -name .bazelversion -delete
 

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -48,6 +48,12 @@ if [[ -n "$SRC_MODULE_ROOT" ]]; then
 	# self-contained .bazelrc), so drop it from the published archive.
 	rm -f "${UNPACK_DIR}/${PREFIX}/.bazelrc"
 
+	# .bazelversion is often a symlink to the repo-root file (e.g. ../../.bazelversion,)
+	# out of the hoisted subtree, so those symlinks dangle in the archive. Drop them: a
+	# consumed module's .bazelversion is ignored, and BCR presubmit controls the
+	# bazel version for the bcr_test_module under e2e/smoke.
+	find "${UNPACK_DIR}/${PREFIX}" -name .bazelversion -delete
+
 	tar -czf "$ARCHIVE" -C "$UNPACK_DIR" "${PREFIX}"
 	rm -rf "$UNPACK_DIR"
 


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
