### PR TITLE
perf: use common.ParseMatcher util in treesitter matchesAllPredicates

### DIFF
--- a/common/treesitter/filters.go
+++ b/common/treesitter/filters.go
@@ -81,7 +81,7 @@ func matchesAllPredicates(q *sitterQuery, m *sitter.QueryMatch, qc *sitter.Query
 			isPositive := operator == "match?"
 
 			expectedCaptureName := q.CaptureNameForId(steps[1].ValueId)
-			regex := common.ParseRegex(q.StringValueForId(steps[2].ValueId))
+			matcher := common.ParseMatcher(q.StringValueForId(steps[2].ValueId))
 
 			for _, c := range m.Captures {
 				captureName := q.CaptureNameForId(c.Index)
@@ -89,7 +89,7 @@ func matchesAllPredicates(q *sitterQuery, m *sitter.QueryMatch, qc *sitter.Query
 					continue
 				}
 
-				if regex.MatchString(c.Node.Content(input)) != isPositive {
+				if matcher(input[c.Node.StartByte():c.Node.EndByte()]) != isPositive {
 					return false
 				}
 			}

--- a/common/treesitter/filters_test.go
+++ b/common/treesitter/filters_test.go
@@ -250,6 +250,19 @@ func TestMatchPredicate_noMatch(t *testing.T) {
 	}
 }
 
+func TestMatchPredicate_literalSubstring(t *testing.T) {
+	ast := mustParseGo(t, goFunctions)
+	// A pattern with no regex meta characters takes the substring-matcher fast
+	// path; "a" appears anywhere in "Bar" and "baz" but not "Foo".
+	q := mustQuery(t, `(function_declaration name: (identifier) @name (#match? @name "a"))`)
+
+	got := collectCaptures(ast, q, "name")
+	want := []string{"Bar", "baz"}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
 func TestNotMatchPredicate(t *testing.T) {
 	ast := mustParseGo(t, goFunctions)
 	// Unexported (lowercase) function names only


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
