### PR TITLE
fix(js): resolve tsconfig mappings (paths, baseUrl, rootDirs) before raw file-label fallback

### DIFF
--- a/language/js/resolve.go
+++ b/language/js/resolve.go
@@ -514,12 +514,8 @@ func (ts *typeScriptLang) resolveImport(
 		return resolution, match, err
 	}
 
-	// References to a label such as a file or file-generating rule
-	if importLabel := ts.getImportLabel(imp.Imp); importLabel != nil {
-		return Resolution_Label, importLabel, nil
-	}
-
-	// References via tsconfig mappings (paths, baseUrl, rootDirs etc.)
+	// References via tsconfig mappings (paths, baseUrl, rootDirs etc.) which tsc
+	// applies during module resolution, before raw file references are considered.
 	if tsconfigPaths := ts.tsconfig.ExpandPaths(impStm.SourcePath, impStm.ImportPath, groupName); len(tsconfigPaths) > 0 {
 		for _, p := range tsconfigPaths {
 			pImp := ImportStatement{
@@ -535,6 +531,11 @@ func (ts *typeScriptLang) resolveImport(
 				return resolution, match, err
 			}
 		}
+	}
+
+	// References to a label such as a file or file-generating rule
+	if importLabel := ts.getImportLabel(imp.Imp); importLabel != nil {
+		return Resolution_Label, importLabel, nil
 	}
 
 	// Native node imports

--- a/language/js/tests/tsconfig_rootdirs_dts/BUILD.in
+++ b/language/js/tests/tsconfig_rootdirs_dts/BUILD.in
@@ -1,0 +1,11 @@
+# gazelle:generation_mode update_only
+
+# The css-module imports in index.ts are satisfied by the generated .d.ts
+# typings under gentypes/ via the tsconfig rootDirs mapping, matching tsc
+# module resolution: no `deps` are generated for the raw .css files. The
+# same-package css is still collected as an asset (the bundler loads the raw
+# file at runtime; only its types come from gentypes/).
+#
+# A real source at the literal import location (sub/util.ts) still wins over
+# virtual typings (gentypes/sub/util.d.ts): tsc probes the importing file's
+# own rootDir first, so the //sub dep is generated.

--- a/language/js/tests/tsconfig_rootdirs_dts/BUILD.out
+++ b/language/js/tests/tsconfig_rootdirs_dts/BUILD.out
@@ -1,0 +1,32 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+
+# gazelle:generation_mode update_only
+
+# The css-module imports in index.ts are satisfied by the generated .d.ts
+# typings under gentypes/ via the tsconfig rootDirs mapping, matching tsc
+# module resolution: no `deps` are generated for the raw .css files. The
+# same-package css is still collected as an asset (the bundler loads the raw
+# file at runtime; only its types come from gentypes/).
+#
+# A real source at the literal import location (sub/util.ts) still wins over
+# virtual typings (gentypes/sub/util.d.ts): tsc probes the importing file's
+# own rootDir first, so the //sub dep is generated.
+
+ts_project(
+    name = "tsconfig_rootdirs_dts",
+    srcs = [
+        "gentypes/styles.module.css.d.ts",
+        "gentypes/sub/styles.module.css.d.ts",
+        "gentypes/sub/util.d.ts",
+        "index.ts",
+    ],
+    assets = ["styles.module.css"],
+    tsconfig = ":tsconfig",
+    deps = ["//sub"],
+)
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    visibility = [":__subpackages__"],
+)

--- a/language/js/tests/tsconfig_rootdirs_dts/WORKSPACE
+++ b/language/js/tests/tsconfig_rootdirs_dts/WORKSPACE
@@ -1,0 +1,2 @@
+# This is a Bazel workspace for the Gazelle test data.
+workspace(name = "tsconfig_rootdirs_dts")

--- a/language/js/tests/tsconfig_rootdirs_dts/gentypes/styles.module.css.d.ts
+++ b/language/js/tests/tsconfig_rootdirs_dts/gentypes/styles.module.css.d.ts
@@ -1,0 +1,4 @@
+declare const styles: {
+    readonly own: string;
+};
+export default styles;

--- a/language/js/tests/tsconfig_rootdirs_dts/gentypes/sub/styles.module.css.d.ts
+++ b/language/js/tests/tsconfig_rootdirs_dts/gentypes/sub/styles.module.css.d.ts
@@ -1,0 +1,4 @@
+declare const styles: {
+    readonly sub: string;
+};
+export default styles;

--- a/language/js/tests/tsconfig_rootdirs_dts/gentypes/sub/util.d.ts
+++ b/language/js/tests/tsconfig_rootdirs_dts/gentypes/sub/util.d.ts
@@ -1,0 +1,1 @@
+export declare const util: number;

--- a/language/js/tests/tsconfig_rootdirs_dts/index.ts
+++ b/language/js/tests/tsconfig_rootdirs_dts/index.ts
@@ -1,0 +1,12 @@
+// tsc resolves these css-module imports to the generated typings under
+// gentypes/ via the tsconfig rootDirs mapping ("./x.module.css" probes
+// "<rootDir>/x.module.css.d.ts" in each rootDir).
+import ownStyles from './styles.module.css';
+import subStyles from './sub/styles.module.css';
+
+// A real source at the literal location wins over virtual typings: tsc probes
+// the importing file's own rootDir first, so this resolves to ./sub/util.ts
+// (a //sub dep) even though gentypes/sub/util.d.ts also exists.
+import { util } from './sub/util';
+
+console.log(ownStyles.own, subStyles.sub, util);

--- a/language/js/tests/tsconfig_rootdirs_dts/styles.module.css
+++ b/language/js/tests/tsconfig_rootdirs_dts/styles.module.css
@@ -1,0 +1,1 @@
+.own { color: red; }

--- a/language/js/tests/tsconfig_rootdirs_dts/sub/BUILD.out
+++ b/language/js/tests/tsconfig_rootdirs_dts/sub/BUILD.out
@@ -1,0 +1,7 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+ts_project(
+    name = "sub",
+    srcs = ["util.ts"],
+    tsconfig = "//:tsconfig",
+)

--- a/language/js/tests/tsconfig_rootdirs_dts/sub/styles.module.css
+++ b/language/js/tests/tsconfig_rootdirs_dts/sub/styles.module.css
@@ -1,0 +1,1 @@
+.sub { color: blue; }

--- a/language/js/tests/tsconfig_rootdirs_dts/sub/util.ts
+++ b/language/js/tests/tsconfig_rootdirs_dts/sub/util.ts
@@ -1,0 +1,1 @@
+export const util = 1;

--- a/language/js/tests/tsconfig_rootdirs_dts/tsconfig.json
+++ b/language/js/tests/tsconfig_rootdirs_dts/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "rootDirs": ["gentypes", "."]
+  }
+}


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
