### PR TITLE
feat(common): add ParseGlobExpressionsWithExcludes

### DIFF
--- a/common/glob.go
+++ b/common/glob.go
@@ -100,7 +100,40 @@ func parseGlobExpression(exp string) GlobExpr {
 	}
 }
 
+// ParseGlobExpressionsWithExcludes matches paths matching any include pattern (or all paths if only excludes are given) and no exclude pattern.
+func ParseGlobExpressionsWithExcludes(includes, excludes []string) (GlobExpr, error) {
+	if len(excludes) == 0 {
+		return ParseGlobExpressions(includes)
+	}
+
+	excludeMatch, err := ParseGlobExpressions(excludes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Excludes-only: match everything that is not excluded.
+	if len(includes) == 0 {
+		return func(p string) bool {
+			return !excludeMatch(p)
+		}, nil
+	}
+
+	includeMatch, err := ParseGlobExpressions(includes)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(p string) bool {
+		return includeMatch(p) && !excludeMatch(p)
+	}, nil
+}
+
+// ParseGlobExpressions matches paths matched by any of the given glob patterns.
 func ParseGlobExpressions(exps []string) (GlobExpr, error) {
+	if len(exps) == 0 {
+		return nil, fmt.Errorf("no glob patterns provided")
+	}
+
 	if len(exps) == 1 {
 		return ParseGlobExpression(exps[0])
 	}

--- a/common/glob_test.go
+++ b/common/glob_test.go
@@ -104,3 +104,98 @@ func TestParseGlobExpressionVsDoublestar(t *testing.T) {
 		}
 	}
 }
+
+func TestParseGlobExpressionsEmpty(t *testing.T) {
+	if _, err := ParseGlobExpressions(nil); err == nil {
+		t.Error("ParseGlobExpressions(nil) should return an error")
+	}
+	if _, err := ParseGlobExpressions([]string{}); err == nil {
+		t.Error("ParseGlobExpressions([]) should return an error")
+	}
+	if _, err := ParseGlobExpressionsWithExcludes(nil, nil); err == nil {
+		t.Error("ParseGlobExpressionsWithExcludes(nil, nil) should return an error")
+	}
+}
+
+// TestParseGlobExpressionsWithExcludes covers include/exclude combination.
+// doublestar cannot express negation, so these use an explicit expectation
+// table rather than cross-checking against doublestar.
+func TestParseGlobExpressionsWithExcludes(t *testing.T) {
+	tests := []struct {
+		name     string
+		includes []string
+		excludes []string
+		matches  map[string]bool
+	}{
+		{
+			name:     "no excludes behaves like includes only",
+			includes: []string{"src/**/*.ts"},
+			excludes: nil,
+			matches: map[string]bool{
+				"src/foo.ts":      true,
+				"src/foo.spec.ts": true,
+				"other/foo.ts":    false,
+			},
+		},
+		{
+			name:     "single exclude",
+			includes: []string{"src/**/*.ts"},
+			excludes: []string{"src/**/*.spec.ts"},
+			matches: map[string]bool{
+				"src/foo.ts":           true,
+				"src/deep/bar.ts":      true,
+				"src/foo.spec.ts":      false,
+				"src/deep/bar.spec.ts": false,
+				"other/foo.ts":         false, // not in includes
+			},
+		},
+		{
+			name:     "multiple excludes",
+			includes: []string{"src/**/*.ts"},
+			excludes: []string{"**/*.spec.ts", "**/*.d.ts", "src/gen/**"},
+			matches: map[string]bool{
+				"src/foo.ts":        true,
+				"src/foo.spec.ts":   false,
+				"src/types.d.ts":    false,
+				"src/gen/x.ts":      false,
+				"src/gen/deep/y.ts": false,
+				"src/keep/z.ts":     true,
+			},
+		},
+		{
+			name:     "multiple includes with exclude",
+			includes: []string{"src/**/*.ts", "src/**/*.tsx"},
+			excludes: []string{"**/*.spec.ts"},
+			matches: map[string]bool{
+				"src/foo.ts":      true,
+				"src/foo.tsx":     true,
+				"src/foo.spec.ts": false,
+			},
+		},
+		{
+			name:     "excludes only matches everything else",
+			includes: nil,
+			excludes: []string{"**/*.spec.ts"},
+			matches: map[string]bool{
+				"foo.ts":          true,
+				"a/b/c.go":        true,
+				"foo.spec.ts":     false,
+				"a/b/foo.spec.ts": false,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := ParseGlobExpressionsWithExcludes(tc.includes, tc.excludes)
+			if err != nil {
+				t.Fatalf("ParseGlobExpressionsWithExcludes(%q, %q) returned error %v", tc.includes, tc.excludes, err)
+			}
+			for path, want := range tc.matches {
+				if got := expr(path); got != want {
+					t.Errorf("includes=%q excludes=%q: match(%q) = %v, want %v", tc.includes, tc.excludes, path, got, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Combines include and exclude glob patterns into a single matcher, for upcoming SourceGlob(exclude) support in orion.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
