### PR TITLE
refactor: return errors from ParseRegex/ParseMatcher instead of panicking

### DIFF
--- a/common/regex.go
+++ b/common/regex.go
@@ -20,21 +20,25 @@ var matcherCache = sync.Map{}
 // Parse a regex and return a regexp.Regexp.
 // Use if the full regexp.Regexp API is needed (e.g. capture groups), otherwise
 // the ParseMatcher() API is more efficient for simple substring matches.
-// Panics if the regex is invalid. Caches parsed regexes for efficiency.
-func ParseRegex(regexStr string) *regexp.Regexp {
+// Returns an error if the regex is invalid. Caches parsed regexes for efficiency.
+func ParseRegex(regexStr string) (*regexp.Regexp, error) {
 	re, found := regexCache.Load(regexStr)
 	if !found {
-		re, _ = regexCache.LoadOrStore(regexStr, regexp.MustCompile(regexStr))
+		compiled, err := regexp.Compile(regexStr)
+		if err != nil {
+			return nil, err
+		}
+		re, _ = regexCache.LoadOrStore(regexStr, compiled)
 	}
 
-	return re.(*regexp.Regexp)
+	return re.(*regexp.Regexp), nil
 }
 
 // Parse a regex or simple substring and return a BytesMatcher.
-// Panics if the regex is invalid. Caches parsed regexes for efficiency.
-func ParseMatcher(matchExpr string) BytesMatcher {
+// Returns an error if the regex is invalid. Caches parsed regexes for efficiency.
+func ParseMatcher(matchExpr string) (BytesMatcher, error) {
 	if m, found := matcherCache.Load(matchExpr); found {
-		return m.(BytesMatcher)
+		return m.(BytesMatcher), nil
 	}
 
 	var m BytesMatcher
@@ -44,9 +48,13 @@ func ParseMatcher(matchExpr string) BytesMatcher {
 			return bytes.Contains(b, needle)
 		}
 	} else {
-		m = ParseRegex(matchExpr).Match
+		re, err := ParseRegex(matchExpr)
+		if err != nil {
+			return nil, err
+		}
+		m = re.Match
 	}
 
 	actual, _ := matcherCache.LoadOrStore(matchExpr, m)
-	return actual.(BytesMatcher)
+	return actual.(BytesMatcher), nil
 }

--- a/common/regex_test.go
+++ b/common/regex_test.go
@@ -27,7 +27,10 @@ func TestParseMatcherVsRegexp(t *testing.T) {
 	}
 
 	for pattern, inputs := range tests {
-		matcher := ParseMatcher(pattern)
+		matcher, err := ParseMatcher(pattern)
+		if err != nil {
+			t.Fatalf("ParseMatcher(%q) returned an error: %v", pattern, err)
+		}
 		re := regexp.MustCompile(pattern)
 		for _, input := range inputs {
 			if matcher([]byte(input)) != re.Match([]byte(input)) {
@@ -37,29 +40,39 @@ func TestParseMatcherVsRegexp(t *testing.T) {
 	}
 }
 
-func TestParseMatcherInvalidRegexPanics(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Fatal("expected ParseMatcher to panic on an invalid regex")
-		}
-	}()
+func TestParseMatcherInvalidRegexErrors(t *testing.T) {
 	// Has a metacharacter (so it takes the regex path) and is invalid.
-	ParseMatcher("[unclosed")
+	m, err := ParseMatcher("[unclosed")
+	if err == nil {
+		t.Fatal("expected ParseMatcher to return an error on an invalid regex")
+	}
+	if m != nil {
+		t.Error("expected ParseMatcher to return a nil matcher on an invalid regex")
+	}
 }
 
 func TestParseRegexCaches(t *testing.T) {
 	// ParseRegex returns the cached *regexp.Regexp, so repeated calls for the
 	// same expression return the identical pointer.
-	if ParseRegex("a.c") != ParseRegex("a.c") {
+	a, err := ParseRegex("a.c")
+	if err != nil {
+		t.Fatalf("ParseRegex returned an error: %v", err)
+	}
+	b, err := ParseRegex("a.c")
+	if err != nil {
+		t.Fatalf("ParseRegex returned an error: %v", err)
+	}
+	if a != b {
 		t.Error("ParseRegex did not return a cached instance for the same expression")
 	}
 }
 
-func TestParseRegexInvalidPanics(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Fatal("expected ParseRegex to panic on an invalid regex")
-		}
-	}()
-	ParseRegex("[unclosed")
+func TestParseRegexInvalidErrors(t *testing.T) {
+	re, err := ParseRegex("[unclosed")
+	if err == nil {
+		t.Fatal("expected ParseRegex to return an error on an invalid regex")
+	}
+	if re != nil {
+		t.Error("expected ParseRegex to return a nil regexp on an invalid regex")
+	}
 }

--- a/common/treesitter/filters.go
+++ b/common/treesitter/filters.go
@@ -1,7 +1,6 @@
 package treesitter
 
 import (
-	common "github.com/aspect-build/aspect-gazelle/common"
 	sitter "github.com/smacker/go-tree-sitter"
 )
 
@@ -81,7 +80,7 @@ func matchesAllPredicates(q *sitterQuery, m *sitter.QueryMatch, qc *sitter.Query
 			isPositive := operator == "match?"
 
 			expectedCaptureName := q.CaptureNameForId(steps[1].ValueId)
-			matcher := common.ParseMatcher(q.StringValueForId(steps[2].ValueId))
+			matcher := q.MatcherForId(steps[2].ValueId)
 
 			for _, c := range m.Captures {
 				captureName := q.CaptureNameForId(c.Index)

--- a/common/treesitter/query.go
+++ b/common/treesitter/query.go
@@ -1,6 +1,11 @@
 package treesitter
 
-import sitter "github.com/smacker/go-tree-sitter"
+import (
+	"fmt"
+
+	common "github.com/aspect-build/aspect-gazelle/common"
+	sitter "github.com/smacker/go-tree-sitter"
+)
 
 // Basic wrapper around sitter.Query to cache tree-sitter cgo calls.
 type sitterQuery struct {
@@ -10,6 +15,10 @@ type sitterQuery struct {
 	stringValues      []string
 	captureNames      []string
 	predicatePatterns [][][]sitter.QueryPredicateStep
+
+	// Pre-parsed match?/not-match? predicate expressions, indexed by the
+	// predicate string value id. Nil for string values that are not matchers.
+	matchers []common.BytesMatcher
 }
 
 var _ TreeQuery = (*sitterQuery)(nil)
@@ -31,8 +40,23 @@ func newSitterQuery(lang *sitter.Language, query string) (*sitterQuery, error) {
 	}
 
 	predicatePatterns := make([][][]sitter.QueryPredicateStep, q.PatternCount())
+	matchers := make([]common.BytesMatcher, q.StringCount())
 	for i := uint32(0); i < q.PatternCount(); i++ {
 		predicatePatterns[i] = q.PredicatesForPattern(i)
+
+		// Parse match? predicate expressions so an invalid expression fails
+		// here instead of when the query is run against a match.
+		for _, steps := range predicatePatterns[i] {
+			switch stringValues[steps[0].ValueId] {
+			case "match?", "not-match?":
+				exprId := steps[2].ValueId
+				m, err := common.ParseMatcher(stringValues[exprId])
+				if err != nil {
+					return nil, fmt.Errorf("invalid %s predicate expression %q: %w", stringValues[steps[0].ValueId], stringValues[exprId], err)
+				}
+				matchers[exprId] = m
+			}
+		}
 	}
 
 	return &sitterQuery{
@@ -40,6 +64,7 @@ func newSitterQuery(lang *sitter.Language, query string) (*sitterQuery, error) {
 		stringValues:      stringValues,
 		captureNames:      captureNames,
 		predicatePatterns: predicatePatterns,
+		matchers:          matchers,
 	}, nil
 }
 
@@ -55,4 +80,9 @@ func (q *sitterQuery) CaptureNameForId(id uint32) string {
 
 func (q *sitterQuery) PredicatesForPattern(patternIndex uint32) [][]sitter.QueryPredicateStep {
 	return q.predicatePatterns[patternIndex]
+}
+
+// The pre-parsed matcher for a match? predicate expression string value id.
+func (q *sitterQuery) MatcherForId(id uint32) common.BytesMatcher {
+	return q.matchers[id]
 }


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
