### PR TITLE
fix: resolve deps for files in tsconfig 'types'

### DIFF
--- a/language/js/generate.go
+++ b/language/js/generate.go
@@ -531,7 +531,8 @@ func (ts *typeScriptLang) collectTsConfigImports(cfg *JsGazelleConfig, args lang
 	for _, t := range tsconfig.Types {
 		if !cfg.IsImportIgnored(t) {
 			imp := t
-			if len(t) > 0 && (t[0] == '.' || t[0] == '/') {
+			isLocalRef := len(t) > 0 && (t[0] == '.' || t[0] == '/')
+			if isLocalRef {
 				imp = toImportSpecPath("", SourcePath, t)
 			}
 			imports = append(imports, ImportStatement{
@@ -543,6 +544,13 @@ func (ts *typeScriptLang) collectTsConfigImports(cfg *JsGazelleConfig, args lang
 				SourcePath: SourcePath,
 				TypesOnly:  true,
 			})
+
+			// Process the discovered "types" imports to find any of their
+			// depednencies which should also be included
+			if isLocalRef {
+				parsed := ts.collectImports(cfg, cache.Get(args.Config), args.Config.RepoRoot, imp)
+				imports = append(imports, parsed.Imports...)
+			}
 		}
 	}
 

--- a/language/js/tests/tsconfig_dts_types_imports/BUILD.in
+++ b/language/js/tests/tsconfig_dts_types_imports/BUILD.in
@@ -1,0 +1,1 @@
+# gazelle:js_files src/**/*.ts

--- a/language/js/tests/tsconfig_dts_types_imports/BUILD.out
+++ b/language/js/tests/tsconfig_dts_types_imports/BUILD.out
@@ -1,0 +1,14 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
+
+# gazelle:js_files src/**/*.ts
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    visibility = [":__subpackages__"],
+    deps = [
+        ":helpers.d.ts",
+        ":types.d.ts",
+        "//dep",
+    ],
+)

--- a/language/js/tests/tsconfig_dts_types_imports/dep/BUILD.in
+++ b/language/js/tests/tsconfig_dts_types_imports/dep/BUILD.in
@@ -1,0 +1,1 @@
+# gazelle:js_files **/*.ts

--- a/language/js/tests/tsconfig_dts_types_imports/dep/BUILD.out
+++ b/language/js/tests/tsconfig_dts_types_imports/dep/BUILD.out
@@ -1,0 +1,15 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+
+# gazelle:js_files **/*.ts
+
+ts_project(
+    name = "dep",
+    srcs = ["lib.ts"],
+    tsconfig = ":tsconfig",
+)
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    visibility = [":__subpackages__"],
+)

--- a/language/js/tests/tsconfig_dts_types_imports/dep/lib.ts
+++ b/language/js/tests/tsconfig_dts_types_imports/dep/lib.ts
@@ -1,0 +1,1 @@
+export const Foo = 'foo';

--- a/language/js/tests/tsconfig_dts_types_imports/dep/tsconfig.json
+++ b/language/js/tests/tsconfig_dts_types_imports/dep/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "compilerOptions": {}
+}

--- a/language/js/tests/tsconfig_dts_types_imports/helpers.d.ts
+++ b/language/js/tests/tsconfig_dts_types_imports/helpers.d.ts
@@ -1,0 +1,1 @@
+export declare function helper(): void;

--- a/language/js/tests/tsconfig_dts_types_imports/tsconfig.json
+++ b/language/js/tests/tsconfig_dts_types_imports/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "types": ["./types.d.ts"]
+  }
+}

--- a/language/js/tests/tsconfig_dts_types_imports/types.d.ts
+++ b/language/js/tests/tsconfig_dts_types_imports/types.d.ts
@@ -1,0 +1,5 @@
+import { Foo } from './dep/lib';
+import { helper } from './helpers';
+
+export declare const Bar: typeof Foo;
+export declare const doThing: typeof helper;


### PR DESCRIPTION
If a file referenced in 'types' has dependencies of its own, we should resolve these to ensure they're also included in the imports. Otherwise, any imports from them will result in an 'unknown dependency' error

---

### Test plan

<!-- Delete any which do not apply -->

- New test cases added: Adds tests with `tsconfig.json` including `types` files with their own dependencies. Resulting `ts_config` rules include the `types` file and any subdependencies as deps
