### PR TITLE
docs: clarify that only the aspect_gazelle_prebuilt module is needed when not building from source

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -62,6 +62,12 @@ if [[ -n "$SRC_MODULE_ROOT" ]]; then
 	rm -rf "$UNPACK_DIR"
 
 	cat <<EOF
+> [!NOTE]
+> \`${MODULE_NAME}\` is only needed when **building the Gazelle binary from source**.
+> If you use [\`aspect_gazelle_prebuilt\`](https://github.com/aspect-build/aspect-gazelle/tree/main/prebuilt),
+> its functionality is already included in the prebuilt binary and no other
+> \`aspect_gazelle_*\` module is required.
+
 Add to your \`MODULE.bazel\`:
 
 \`\`\`starlark
@@ -162,6 +168,13 @@ tar --file "$ARCHIVE_TMP" --append \
 gzip <"$ARCHIVE_TMP" >"$ARCHIVE"
 
 cat <<EOF
+> [!NOTE]
+> \`aspect_gazelle_prebuilt\` is the only module you need — every language and
+> extension is already compiled into the prebuilt binary. The other
+> \`aspect_gazelle_*\` modules (\`aspect_gazelle_js\`, \`aspect_gazelle_kotlin\`,
+> \`aspect_gazelle_orion\`, \`aspect_gazelle_runner\`, ...) are only used when
+> building the Gazelle binary from source.
+
 Add to your \`MODULE.bazel\`:
 
 \`\`\`starlark

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ We provide a variety of enhancements to Gazelle.
 
 The [runner](./runner) enables these enhancements automatically, otherwise manual setup (including patching Gazelle) is required.
 
+The runner has Aspect-endorsed Gazelle languages built in; further Gazelle languages (written with the Go SDK) cannot be added without changes to the [runner](./runner). The built-in languages — the names accepted by the `languages` attribute — are [`buf`](https://github.com/bufbuild/rules_buf/tree/main/gazelle/buf), [`cc`](https://github.com/EngFlow/gazelle_cc/tree/main/language/cc), [`go`](https://github.com/bazel-contrib/bazel-gazelle/tree/master/language/go), [`js`](./language/js), [`kotlin`](./language/kotlin), [`orion`](./language/orion) (AXL extensions), [`proto`](https://github.com/bazel-contrib/bazel-gazelle/tree/master/language/proto), [`python`](https://github.com/bazel-contrib/rules_python/tree/main/gazelle), [`starlark`](https://github.com/bazelbuild/bazel-skylib/tree/main/gazelle/bzl) and [`visibility_extension`](https://github.com/bazel-contrib/bazel-gazelle/tree/master/language/bazel/visibility). This same fixed language set is what the [prebuilt](#prebuilt) binary ships. More may be added upon request (file an issue) if the quality is good and maintenance is likely.
+
 ### Gitignore
 
 Support for `.gitignore` when generating BUILD files. Files (and directories) matched by any `.gitignore` in the workspace are skipped during the walk, so they don't become BUILD-file sources.
@@ -46,7 +48,12 @@ The [runner](./runner) supports a `--watch` mode that uses [watchman](https://fa
 
 ## Prebuilt
 
-The [./prebuilt](./prebuilt) module provides a prebuilt version of the [runner](./runner) as a drop-in replacement for the Gazelle binary, with all enhancements and extensions included, and without the need for any compilation of Go code or Gazelle extensions on the user's machine.
+The [prebuilt](./prebuilt) module provides a prebuilt version of the [runner](./runner).
+
+This is a drop-in replacement for the Gazelle binary, with all the runner enhancements and extensions included, and without the need for any compilation of Gazelle or Gazelle languages on the user's machine. This avoids pulling in transitive bzlmod dependencies such as rules_go, rules_python, and rules_rs (with its LLVM toolchain), which are otherwise required to build Gazelle from source.
+
+> [!NOTE]
+> `aspect_gazelle_prebuilt` is the only module you need — every language and extension is already compiled into the prebuilt binary. The other `aspect_gazelle_*` modules (`aspect_gazelle_js`, `aspect_gazelle_kotlin`, `aspect_gazelle_orion`, `aspect_gazelle_runner`, ...) are only used when building the Gazelle binary from source; do not add them to your `MODULE.bazel` when using the prebuilt module.
 
 ### Why use a prebuilt binary?
 

--- a/language/js/README.md
+++ b/language/js/README.md
@@ -2,6 +2,9 @@
 
 This package is a [Gazelle](https://github.com/bazelbuild/bazel-gazelle) `Language` implementation for [rules_js](https://github.com/aspect-build/rules_js) and [rules_ts](https://github.com/aspect-build/rules_ts).
 
+> [!NOTE]
+> The `aspect_gazelle_js` module is only needed when **building the Gazelle binary from source**. If you use [`aspect_gazelle_prebuilt`](../../prebuilt/), this language is already compiled into the prebuilt binary and no other `aspect_gazelle_*` module is required — the directives documented below work the same either way.
+
 ## Rules
 
 Generated targets include:
@@ -70,7 +73,7 @@ Finally, the `import` statements in the source files are parsed, and dependencie
 
 ## Build setup
 
-> **The setup below is only required when building the Gazelle binary from source.** Users of [`aspect_gazelle_prebuilt`](../../prebuilt/) can skip it entirely — that module ships a prebuilt Gazelle binary, so you don't compile the Rust parser, or need a Go, Rust, or LLVM toolchain, at all.
+> **The setup below is only required when building the Gazelle binary from source.** Users of [`aspect_gazelle_prebuilt`](../../prebuilt/) can skip it entirely — that module ships a prebuilt Gazelle binary, so you don't depend on `aspect_gazelle_js` (or any other `aspect_gazelle_*` module), compile the Rust parser, or need a Go, Rust, or LLVM toolchain at all.
 
 The JS/TS import parser is implemented in Rust (using [oxc](https://oxc.rs/)) and linked into the Gazelle binary via cgo. Building this module therefore compiles a Rust static library through [rules_rs](https://github.com/hermeticbuild/rules_rs) and a hermetic LLVM C/C++ toolchain.
 

--- a/language/kotlin/README.md
+++ b/language/kotlin/README.md
@@ -2,6 +2,9 @@
 
 This is a [Gazelle](https://github.com/bazelbuild/bazel-gazelle) `Language` implementation for Kotlin using the [rules_kotlin](https://github.com/bazelbuild/rules_kotlin) `jvm` rules.
 
+> [!NOTE]
+> The `aspect_gazelle_kotlin` module is only needed when **building the Gazelle binary from source**. If you use [`aspect_gazelle_prebuilt`](../../prebuilt/), this language is already compiled into the prebuilt binary and no other `aspect_gazelle_*` module is required.
+
 This was originally implemented by @jbedard in https://github.com/aspect-build/aspect-cli
 and has been separated out to a standalone git repository and Bazel module.
 

--- a/language/orion/README.md
+++ b/language/orion/README.md
@@ -2,6 +2,9 @@
 
 A BUILD generator where plugins implemented in Starlark can be used to generate BUILD files for bazel projects.
 
+> [!NOTE]
+> The `aspect_gazelle_orion` module is only needed when **building the Gazelle binary from source**. If you use [`aspect_gazelle_prebuilt`](../../prebuilt/), this language is already compiled into the prebuilt binary and no other `aspect_gazelle_*` module is required.
+
 See [Starlark spec](https://github.com/bazelbuild/starlark/blob/master/spec.md), [core Starlark data types](https://bazel.build/rules/lib/core), [Starlark github-linguist](https://github.com/github-linguist/linguist/blob/v7.29.0/lib/linguist/languages.yml#L6831-L6852) for general Starlark docs and information.
 
 ## Why we made it

--- a/prebuilt/README.md
+++ b/prebuilt/README.md
@@ -3,6 +3,13 @@
 A prebuilt distribution of [aspect_gazelle_runner](../runner/) that downloads
 platform-specific binaries from GitHub Releases instead of compiling from source.
 
+> [!NOTE]
+> `aspect_gazelle_prebuilt` is the only module you need — every language and
+> extension is already compiled into the prebuilt binary. The other
+> `aspect_gazelle_*` modules (`aspect_gazelle_js`, `aspect_gazelle_kotlin`,
+> `aspect_gazelle_orion`, `aspect_gazelle_runner`, ...) are only used when
+> building the Gazelle binary from source.
+
 ## Usage
 
 ```starlark


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
