### PR TITLE
refactor: move package.json parsing from the generate phase into the configure phase

### DIFF
--- a/language/js/configure.go
+++ b/language/js/configure.go
@@ -110,9 +110,9 @@ func (ts *typeScriptLang) readConfigurations(c *config.Config, rel string) {
 		}
 	}
 
-	// Anchor for the forwarding ts_config rule generated in package.json-only dirs.
+	// packages - pnpm or arbitrary package.json files
 	if common.WalkHasPath(rel, NpmPackageFilename) {
-		ts.tsconfig.RegisterPackageJsonDir(rel)
+		ts.packageJsonDirs[rel] = struct{}{}
 	}
 }
 

--- a/language/js/generate.go
+++ b/language/js/generate.go
@@ -363,16 +363,23 @@ func (ts *typeScriptLang) addPackageRule(cfg *JsGazelleConfig, args language.Gen
 
 	packageJsonPath := path.Join(args.Rel, NpmPackageFilename)
 
-	parserCache := cache.Get(args.Config)
-	packageJson, _, err := parserCache.LoadOrStoreFile(args.Config.RepoRoot, packageJsonPath, "node.ParsePackageJson", func(path string, content []byte) (any, error) {
-		return node.ParsePackageJson(bytes.NewReader(content))
-	})
-	if err != nil {
-		common.MisconfiguredErrorf(args.Config, "Failed to parse %q imports: %v", packageJsonPath, err)
+	// The package.json may not exist if it is generated or for some reason does not exist on disk.
+	var packageJsonEntries []string
+	if packageJson, err := ts.getPackageJson(args.Config, args.Rel); err != nil {
+		common.MisconfiguredErrorf(args.Config, "Failed to parse %q: %v", packageJsonPath, err)
 		return
+	} else if packageJson != nil {
+		packageJsonEntries = packageJson.Entries
+	} else if slices.Contains(args.GenFiles, NpmPackageFilename) {
+		BazelLog.Debugf("Generated package.json for %q", args.Rel)
+	} else {
+		// A pnpm project with no walkable package.json: either deleted but still
+		// referenced by the lockfile, or excluded from the walk. Entries such as
+		// main/exports/types are not parsed in this case.
+		BazelLog.Warnf("No package.json found for pnpm project %q", args.Rel)
 	}
 
-	for _, impt := range packageJson.(node.PackageJson).Entries {
+	for _, impt := range packageJsonEntries {
 		if cfg.IsImportIgnored(impt) {
 			continue
 		}
@@ -425,6 +432,28 @@ func (ts *typeScriptLang) addPackageRule(cfg *JsGazelleConfig, args language.Gen
 	result.RelsToIndex = append(result.RelsToIndex, ts.tsPackageInfoToRelsToIndex(cfg, args, &npmPackageInfo.TsProjectInfo)...)
 
 	BazelLog.Infof("add rule '%s' '%s:%s'", cfg.packageTargetKind, args.Rel, packageTargetName)
+}
+
+// getPackageJson lazily parses and returns the package.json data of the given
+// directory. Returns nil if the directory does not contain a package.json,
+// an error if the package.json fails to parse. Like the Node.js runtime, a
+// package.json is only parsed (and only fails) when actually consulted.
+func (ts *typeScriptLang) getPackageJson(c *config.Config, rel string) (*node.PackageJson, error) {
+	if _, found := ts.packageJsonDirs[rel]; !found {
+		return nil, nil
+	}
+
+	packageJsonPath := path.Join(rel, NpmPackageFilename)
+
+	packageJson, _, err := cache.Get(c).LoadOrStoreFile(c.RepoRoot, packageJsonPath, "node.ParsePackageJson", func(path string, content []byte) (any, error) {
+		return node.ParsePackageJson(bytes.NewReader(content))
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	pkg := packageJson.(node.PackageJson)
+	return &pkg, nil
 }
 
 // collectTsConfigPackageJsonDeps returns label deps for the package.json files

--- a/language/js/language.go
+++ b/language/js/language.go
@@ -28,6 +28,10 @@ type typeScriptLang struct {
 	// to the parent pnpm project map.
 	pnpmProjects *pnpm.PnpmProjectMap
 
+	// Directories containing a package.json file.
+	// Possibly pnpm projects, possibly just package.json files.
+	packageJsonDirs map[string]struct{}
+
 	// TypeScript configuration across the workspace
 	tsconfig *typescript.TsWorkspace
 }
@@ -39,11 +43,16 @@ var _ language.ModuleAwareLanguage = (*typeScriptLang)(nil)
 // interface. This is the entrypoint for the extension initialization.
 func NewLanguage() language.Language {
 	pnpmProjects := pnpm.NewPnpmProjectMap()
+	packageJsonDirs := make(map[string]struct{})
 
 	return &typeScriptLang{
-		fileLabels:   make(map[string]*label.Label),
-		moduleTypes:  make(map[string][]*label.Label),
-		pnpmProjects: pnpmProjects,
-		tsconfig:     typescript.NewTsWorkspace(pnpmProjects),
+		fileLabels:      make(map[string]*label.Label),
+		moduleTypes:     make(map[string][]*label.Label),
+		pnpmProjects:    pnpmProjects,
+		packageJsonDirs: packageJsonDirs,
+		tsconfig: typescript.NewTsWorkspace(pnpmProjects, func(rel string) bool {
+			_, found := packageJsonDirs[rel]
+			return found
+		}),
 	}
 }

--- a/language/js/tests/bad_package_json-invalid/expectedStderr.txt
+++ b/language/js/tests/bad_package_json-invalid/expectedStderr.txt
@@ -1,1 +1,1 @@
-Failed to parse "package.json" imports: json: cannot unmarshal string into Go value of type gazelle.npmPackageJSON
+Failed to parse "package.json": json: cannot unmarshal string into Go value of type gazelle.npmPackageJSON

--- a/language/js/tests/bad_package_json-no_package_target/BUILD.in
+++ b/language/js/tests/bad_package_json-no_package_target/BUILD.in
@@ -1,0 +1,1 @@
+# gazelle:js_npm_package disabled

--- a/language/js/tests/bad_package_json-no_package_target/BUILD.out
+++ b/language/js/tests/bad_package_json-no_package_target/BUILD.out
@@ -1,0 +1,11 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+# gazelle:js_npm_package disabled
+
+npm_link_all_packages(name = "node_modules")
+
+ts_project(
+    name = "bad_package_json_no_package_target",
+    srcs = ["main.ts"],
+)

--- a/language/js/tests/bad_package_json-no_package_target/WORKSPACE
+++ b/language/js/tests/bad_package_json-no_package_target/WORKSPACE
@@ -1,0 +1,2 @@
+# This is a Bazel workspace for the Gazelle test data.
+workspace(name = "bad_package_json_no_package_target")

--- a/language/js/tests/bad_package_json-no_package_target/main.ts
+++ b/language/js/tests/bad_package_json-no_package_target/main.ts
@@ -1,0 +1,1 @@
+console.log('hello world');

--- a/language/js/tests/bad_package_json-no_package_target/package.json
+++ b/language/js/tests/bad_package_json-no_package_target/package.json
@@ -1,0 +1,4 @@
+not
+even
+23423
+valid

--- a/language/js/tests/bad_package_json-no_package_target/pnpm-lock.yaml
+++ b/language/js/tests/bad_package_json-no_package_target/pnpm-lock.yaml
@@ -1,0 +1,13 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      tslib:
+        specifier: 1.2.3
+        version: 1.2.3

--- a/language/js/tests/bad_package_json/expectedStderr.txt
+++ b/language/js/tests/bad_package_json/expectedStderr.txt
@@ -1,1 +1,1 @@
-Failed to parse "package.json" imports: invalid character 'o' in literal null (expecting 'u')
+Failed to parse "package.json": invalid character 'o' in literal null (expecting 'u')

--- a/language/js/tests/excluded_package_json/BUILD.in
+++ b/language/js/tests/excluded_package_json/BUILD.in
@@ -1,0 +1,2 @@
+# gazelle:js_npm_package enabled
+# gazelle:exclude package.json

--- a/language/js/tests/excluded_package_json/BUILD.out
+++ b/language/js/tests/excluded_package_json/BUILD.out
@@ -1,0 +1,19 @@
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+# gazelle:js_npm_package enabled
+# gazelle:exclude package.json
+
+npm_link_all_packages(name = "node_modules")
+
+ts_project(
+    name = "excluded_package_json_lib",
+    srcs = ["main.ts"],
+)
+
+npm_package(
+    name = "excluded_package_json",
+    srcs = [":excluded_package_json_lib"],
+    visibility = ["//:__pkg__"],
+)

--- a/language/js/tests/excluded_package_json/WORKSPACE
+++ b/language/js/tests/excluded_package_json/WORKSPACE
@@ -1,0 +1,2 @@
+# This is a Bazel workspace for the Gazelle test data.
+workspace(name = "excluded_package_json")

--- a/language/js/tests/excluded_package_json/main.ts
+++ b/language/js/tests/excluded_package_json/main.ts
@@ -1,0 +1,1 @@
+console.log('hello world');

--- a/language/js/tests/excluded_package_json/package.json
+++ b/language/js/tests/excluded_package_json/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "excluded-package-json",
+  "private": true,
+  "main": "main.js"
+}

--- a/language/js/tests/excluded_package_json/pnpm-lock.yaml
+++ b/language/js/tests/excluded_package_json/pnpm-lock.yaml
@@ -1,0 +1,13 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      tslib:
+        specifier: 1.2.3
+        version: 1.2.3

--- a/language/js/tests/generated_package_json/BUILD.in
+++ b/language/js/tests/generated_package_json/BUILD.in
@@ -1,0 +1,7 @@
+# gazelle:js_npm_package enabled
+
+genrule(
+    name = "gen_package_json",
+    outs = ["package.json"],
+    cmd = "echo '{}' > $@",
+)

--- a/language/js/tests/generated_package_json/BUILD.out
+++ b/language/js/tests/generated_package_json/BUILD.out
@@ -1,0 +1,27 @@
+load("@aspect_rules_js//npm:defs.bzl", "npm_package")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+# gazelle:js_npm_package enabled
+
+genrule(
+    name = "gen_package_json",
+    outs = ["package.json"],
+    cmd = "echo '{}' > $@",
+)
+
+npm_link_all_packages(name = "node_modules")
+
+ts_project(
+    name = "generated_package_json_lib",
+    srcs = ["main.ts"],
+)
+
+npm_package(
+    name = "generated_package_json",
+    srcs = [
+        "package.json",
+        ":generated_package_json_lib",
+    ],
+    visibility = ["//:__pkg__"],
+)

--- a/language/js/tests/generated_package_json/WORKSPACE
+++ b/language/js/tests/generated_package_json/WORKSPACE
@@ -1,0 +1,2 @@
+# This is a Bazel workspace for the Gazelle test data.
+workspace(name = "generated_package_json")

--- a/language/js/tests/generated_package_json/main.ts
+++ b/language/js/tests/generated_package_json/main.ts
@@ -1,0 +1,1 @@
+console.log('hello world');

--- a/language/js/tests/generated_package_json/pnpm-lock.yaml
+++ b/language/js/tests/generated_package_json/pnpm-lock.yaml
@@ -1,0 +1,13 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      tslib:
+        specifier: 1.2.3
+        version: 1.2.3

--- a/language/js/typescript/config.go
+++ b/language/js/typescript/config.go
@@ -23,10 +23,6 @@ type TsConfigMap struct {
 	// loading on multiple threads in the generate phase.
 	configFiles map[string]map[string]*workspacePath
 
-	// Dirs with a package.json; anchors for forwarding ts_config rules.
-	// Same configure-phase-write / generate-phase-read invariant as `configFiles`.
-	packageJsonDirs map[string]struct{}
-
 	configs      map[string]*TsConfig
 	configsMutex sync.RWMutex
 	pnpmProjects *pnpm.PnpmProjectMap
@@ -34,33 +30,33 @@ type TsConfigMap struct {
 
 type TsWorkspace struct {
 	cm *TsConfigMap
+
+	// hasPackageJson reports whether a dir contains a package.json; such dirs
+	// are anchors for forwarding ts_config rules. The backing data must be
+	// recorded during the configure phase (single threaded) and is only
+	// queried during the generate phase, matching the `configFiles` invariant.
+	hasPackageJson func(rel string) bool
 }
 
-func NewTsWorkspace(pnpmProjects *pnpm.PnpmProjectMap) *TsWorkspace {
+func NewTsWorkspace(pnpmProjects *pnpm.PnpmProjectMap, hasPackageJson func(rel string) bool) *TsWorkspace {
 	return &TsWorkspace{
 		cm: &TsConfigMap{
-			configFiles:     make(map[string]map[string]*workspacePath),
-			packageJsonDirs: make(map[string]struct{}),
-			configs:         make(map[string]*TsConfig),
-			pnpmProjects:    pnpmProjects,
-			configsMutex:    sync.RWMutex{},
+			configFiles:  make(map[string]map[string]*workspacePath),
+			configs:      make(map[string]*TsConfig),
+			pnpmProjects: pnpmProjects,
+			configsMutex: sync.RWMutex{},
 		},
+		hasPackageJson: hasPackageJson,
 	}
 }
 
-// RegisterPackageJsonDir records a dir containing a package.json so FindConfig
-// anchors at the local forwarding ts_config rather than the ancestor tsconfig.
-func (tc *TsWorkspace) RegisterPackageJsonDir(rel string) {
-	tc.cm.packageJsonDirs[rel] = struct{}{}
-}
-
 // ClosestAncestorPackageJsonDir returns the closest strictly-ancestor dir of
-// `dir` registered as a package.json dir, or "", false.
+// `dir` containing a package.json, or "", false.
 func (tc *TsWorkspace) ClosestAncestorPackageJsonDir(dir string) (string, bool) {
 	for dir != "" {
 		base, _ := path.Split(dir)
 		dir = strings.TrimSuffix(base, "/")
-		if _, ok := tc.cm.packageJsonDirs[dir]; ok {
+		if tc.hasPackageJson(dir) {
 			return dir, true
 		}
 	}
@@ -183,10 +179,8 @@ func (tc *TsWorkspace) FindConfig(dir, groupName string) (string, string, *TsCon
 		}
 
 		// Record the closest package.json dir; validated against configRel below.
-		if !foundPackageJsonDir {
-			if _, ok := tc.cm.packageJsonDirs[dir]; ok {
-				packageJsonDirRel, foundPackageJsonDir = dir, true
-			}
+		if !foundPackageJsonDir && tc.hasPackageJson(dir) {
+			packageJsonDirRel, foundPackageJsonDir = dir, true
 		}
 
 		if dir == "" {

--- a/language/js/typescript/config_test.go
+++ b/language/js/typescript/config_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestGetTsConfigFromPath(t *testing.T) {
 	t.Run("cache hit returns identical pointer", func(t *testing.T) {
-		tc := NewTsWorkspace(nil)
+		tc := NewTsWorkspace(nil, func(string) bool { return false })
 		tc.SetTsConfigFile(".", "tests", "", "base.tsconfig.json")
 
 		first := tc.GetTsConfigFile("tests", "")
@@ -37,7 +37,7 @@ func TestGetTsConfigFromPath(t *testing.T) {
 	})
 
 	t.Run("failure leaves InvalidTsconfig sentinel and stays nil on re-call", func(t *testing.T) {
-		tc := NewTsWorkspace(nil)
+		tc := NewTsWorkspace(nil, func(string) bool { return false })
 		tc.SetTsConfigFile(".", "tests", "", "does-not-exist.json")
 
 		if c := tc.GetTsConfigFile("tests", ""); c != nil {
@@ -76,10 +76,14 @@ func TestGetTsConfigFromPath(t *testing.T) {
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
-				ws := NewTsWorkspace(nil)
+				registered := make(map[string]struct{}, len(tc.registered))
 				for _, r := range tc.registered {
-					ws.RegisterPackageJsonDir(r)
+					registered[r] = struct{}{}
 				}
+				ws := NewTsWorkspace(nil, func(rel string) bool {
+					_, ok := registered[rel]
+					return ok
+				})
 				gotDir, gotOk := ws.ClosestAncestorPackageJsonDir(tc.input)
 				if gotDir != tc.wantDir || gotOk != tc.wantOk {
 					t.Errorf("ClosestAncestorPackageJsonDir(%q) = (%q, %v); want (%q, %v)",
@@ -90,7 +94,7 @@ func TestGetTsConfigFromPath(t *testing.T) {
 	})
 
 	t.Run("concurrent callers see same cached pointer", func(t *testing.T) {
-		tc := NewTsWorkspace(nil)
+		tc := NewTsWorkspace(nil, func(string) bool { return false })
 		tc.SetTsConfigFile(".", "tests", "", "base.tsconfig.json")
 
 		const goroutines = 32


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
