### PR TITLE
fix: support '*' patterns and multi-target conditions in '#' subpath imports

### DIFF
--- a/language/js/node/package.go
+++ b/language/js/node/package.go
@@ -37,27 +37,51 @@ type PackageJson struct {
 	// All entry point files such as the 'main' and 'exports' fields.
 	Entries []string
 
-	// Subpath imports from the 'imports' field, keyed by the '#'-prefixed
-	// specifier. Values are the raw mapping targets: './'-relative files
-	// within the package, or external package specifiers. Targets are
-	// sorted, JSON condition order is not preserved.
-	// Nil if package.json has no 'imports' field.
+	// Exact (non-pattern) subpath imports from the 'imports' field, mapped to their sorted targets.
 	Imports map[string][]string
+
+	// '*' subpath import patterns from the 'imports' field, sorted by resolution priority.
+	ImportPatterns []SubpathImportPattern
+}
+
+// SubpathImportPattern is a '*' subpath import pattern such as
+// "#internal/*": "./src/internal/*.js", split around the specifier '*'.
+// See https://nodejs.org/api/packages.html#subpath-imports
+type SubpathImportPattern struct {
+	Prefix, Suffix string
+
+	// The sorted mapping targets, '*'s not yet substituted.
+	Targets []string
+}
+
+// ResolveImport resolves a subpath import specifier to its mapping targets,
+// matching and expanding '*' subpath patterns.
+func (p *PackageJson) ResolveImport(specifier string) []string {
+	// Exact matches take precedence over '*' patterns.
+	if targets, found := p.Imports[specifier]; found {
+		return targets
+	}
+
+	// Patterns are pre-sorted by priority; the first match wins.
+	for _, pat := range p.ImportPatterns {
+		if len(specifier) <= len(pat.Prefix)+len(pat.Suffix) || !strings.HasPrefix(specifier, pat.Prefix) || !strings.HasSuffix(specifier, pat.Suffix) {
+			continue
+		}
+
+		// Substitute the pattern match into the targets.
+		matched := specifier[len(pat.Prefix) : len(specifier)-len(pat.Suffix)]
+		targets := make([]string, len(pat.Targets))
+		for i, target := range pat.Targets {
+			targets[i] = strings.ReplaceAll(target, "*", matched)
+		}
+		return targets
+	}
+
+	return nil
 }
 
 func (p *PackageJson) addEntry(file string) {
 	p.Entries = append(p.Entries, path.Clean(file))
-}
-
-func (p *PackageJson) addImport(specifier, target string) {
-	specifier = path.Clean(specifier)
-	p.Imports[specifier] = append(p.Imports[specifier], target)
-
-	// Only './'-relative targets are files within the package, otherwise
-	// the target is an external package specifier.
-	if strings.HasPrefix(target, "./") {
-		p.addEntry(target)
-	}
 }
 
 // Extract the package metadata from the package.json file such as the
@@ -142,13 +166,23 @@ func ParsePackageJson(packageJsonReader io.Reader) (PackageJson, error) {
 	// https://nodejs.org/api/packages.html#subpath-imports
 	if c.Imports != nil {
 		if imports, ok := c.Imports.(map[string]any); ok {
-			pkg.Imports = make(map[string][]string)
+			rawImports := make(map[string][]string)
+			addImport := func(specifier, target string) {
+				specifier = path.Clean(specifier)
+				rawImports[specifier] = append(rawImports[specifier], target)
+
+				// Only './'-relative targets are files within the package, otherwise
+				// the target is an external package specifier.
+				if strings.HasPrefix(target, "./") {
+					pkg.addEntry(target)
+				}
+			}
 
 			for importKey, imprt := range imports {
 				switch i := imprt.(type) {
 				case string:
 					// Regular subpath import
-					pkg.addImport(importKey, i)
+					addImport(importKey, i)
 				case nil:
 					// Excluded target, same as 'exports' null targets.
 					break
@@ -157,7 +191,7 @@ func ParsePackageJson(packageJsonReader io.Reader) (PackageJson, error) {
 					for subIKey, subI := range i {
 						switch subI := subI.(type) {
 						case string:
-							pkg.addImport(importKey, subI)
+							addImport(importKey, subI)
 						default:
 							BazelLog.Warnf("Unknown package.json imports.%s.%s type: %T", importKey, subIKey, subI)
 						}
@@ -167,11 +201,40 @@ func ParsePackageJson(packageJsonReader io.Reader) (PackageJson, error) {
 				}
 			}
 
-			// Conditional import targets are collected in undefined map iteration
-			// order. Sort for determinism.
-			for _, targets := range pkg.Imports {
+			// Validate and index the raw mappings for resolution: exact
+			// specifiers split from '*' patterns, targets sorted and patterns
+			// ordered by resolution priority.
+			for key, targets := range rawImports {
 				slices.Sort(targets)
+
+				prefix, suffix, isPattern := strings.Cut(key, "*")
+				if !isPattern {
+					if pkg.Imports == nil {
+						pkg.Imports = make(map[string][]string, len(rawImports))
+					}
+					pkg.Imports[key] = targets
+				} else if strings.Contains(suffix, "*") {
+					BazelLog.Warnf("Invalid package.json imports key %q: multiple '*'s", key)
+				} else {
+					pkg.ImportPatterns = append(pkg.ImportPatterns, SubpathImportPattern{Prefix: prefix, Suffix: suffix, Targets: targets})
+				}
 			}
+
+			// Node resolution priority (PATTERN_KEY_COMPARE): the longest prefix,
+			// then the longest suffix. Equal-length patterns can not match the same
+			// specifier; order those lexicographically for determinism.
+			slices.SortFunc(pkg.ImportPatterns, func(a, b SubpathImportPattern) int {
+				if d := len(b.Prefix) - len(a.Prefix); d != 0 {
+					return d
+				}
+				if d := len(b.Suffix) - len(a.Suffix); d != 0 {
+					return d
+				}
+				if d := strings.Compare(a.Prefix, b.Prefix); d != 0 {
+					return d
+				}
+				return strings.Compare(a.Suffix, b.Suffix)
+			})
 		} else {
 			BazelLog.Warnf("Unknown package.json imports type: %T", c.Imports)
 		}

--- a/language/js/node/package_test.go
+++ b/language/js/node/package_test.go
@@ -51,7 +51,7 @@ func TestParsePackageJson(t *testing.T) {
 		assertPackageJsonImports(t, `{"main":"foo.js"}`, nil)
 		assertPackageJsonImports(t, `{"imports":{"#utils":"./src/utils.js"}}`, map[string][]string{"#utils": {"./src/utils.js"}})
 		assertPackageJsonImports(t, `{"imports":{"#dep":"external-pkg"}}`, map[string][]string{"#dep": {"external-pkg"}})
-		assertPackageJsonImports(t, `{"imports":{"#dep":null}}`, map[string][]string{})
+		assertPackageJsonImports(t, `{"imports":{"#dep":null}}`, nil)
 
 		// Conditional subpath imports. Targets are sorted regardless of JSON
 		// condition order.
@@ -66,8 +66,73 @@ func TestParsePackageJson(t *testing.T) {
 
 		// Invalid types
 		assertPackageJsonImports(t, `{"imports":"./foo.js"}`, nil)
-		assertPackageJsonImports(t, `{"imports":{"#dep":123}}`, map[string][]string{})
+		assertPackageJsonImports(t, `{"imports":{"#dep":123}}`, nil)
 	})
+
+	t.Run("subpath import patterns", func(t *testing.T) {
+		pkg := parsePackageJson(t, `{"imports":{
+			"#internal/*": "./src/internal/*.js",
+			"#internal/special": "./special.js",
+			"#internal/deep/*": "./src/deep/*.mjs",
+			"#suffix/*.js": "./s/*.js",
+			"#multi/*": {"node": "./n/*.cjs", "default": "ext-pkg/*"}
+		}}`)
+
+		// Exact matches take precedence over patterns
+		assertResolveImport(t, pkg, "#internal/special", "./special.js")
+
+		// Pattern matches, '*' may span '/'
+		assertResolveImport(t, pkg, "#internal/foo", "./src/internal/foo.js")
+		assertResolveImport(t, pkg, "#internal/a/b", "./src/internal/a/b.js")
+
+		// The longest matching prefix wins
+		assertResolveImport(t, pkg, "#internal/deep/x", "./src/deep/x.mjs")
+
+		// With equal prefixes, the longest matching suffix wins
+		suffixes := parsePackageJson(t, `{"imports":{"#a/*":"./plain/*.js","#a/*.js":"./js/*.mjs"}}`)
+		assertResolveImport(t, suffixes, "#a/foo.js", "./js/foo.mjs")
+
+		// A higher-priority pattern that prefix/suffix-matches but has only an
+		// empty '*' is skipped, falling through to a lower-priority match.
+		shadow := parsePackageJson(t, `{"imports":{"#x/*":"./a/*.js","#x/y*":"./b/*.js"}}`)
+		assertResolveImport(t, shadow, "#x/y", "./a/y.js")
+
+		// Patterns with a suffix
+		assertResolveImport(t, pkg, "#suffix/y.js", "./s/y.js")
+
+		// Conditional pattern targets are all expanded
+		assertResolveImport(t, pkg, "#multi/x", "./n/x.cjs", "ext-pkg/x")
+
+		// No match: unknown specifiers and empty '*' matches
+		assertResolveImport(t, pkg, "#unknown")
+		assertResolveImport(t, pkg, "#internal/")
+
+		// Invalid pattern keys with multiple '*'s are dropped when parsed
+		invalid := parsePackageJson(t, `{"imports":{"#bad/*/*":"./x/*.js"}}`)
+		assertResolveImport(t, invalid, "#bad/a/b")
+
+		// An overlapping prefix and suffix has no (non-empty) '*' match and
+		// must not panic on the out-of-range substring: '#abc' starts with
+		// '#ab' and ends with 'bc' but is shorter than their sum.
+		overlap := parsePackageJson(t, `{"imports":{"#ab*bc":"./x/*.js"}}`)
+		assertResolveImport(t, overlap, "#abc")
+	})
+}
+
+func assertResolveImport(t *testing.T, pkg PackageJson, specifier string, expectedTargets ...string) {
+	t.Helper()
+
+	actual := pkg.ResolveImport(specifier)
+	if len(expectedTargets) == 0 {
+		if actual != nil {
+			t.Errorf("ResolveImport(%q) expected no targets, got %q", specifier, actual)
+		}
+		return
+	}
+
+	if !slices.Equal(actual, expectedTargets) {
+		t.Errorf("ResolveImport(%q) expected %q, got %q", specifier, expectedTargets, actual)
+	}
 }
 
 func parsePackageJson(t *testing.T, packageJson string) PackageJson {
@@ -93,23 +158,27 @@ func assertParsePackageJsonEntries(t *testing.T, packageJson string, expectedEnt
 	}
 }
 
+// assertPackageJsonImports asserts the exact (non-pattern) 'imports' compiled
+// when parsing the package.json. A nil expectation asserts no 'imports' field.
 func assertPackageJsonImports(t *testing.T, packageJson string, expectedImports map[string][]string) {
 	t.Helper()
-	assertSpecifierMap(t, "imports", packageJson, parsePackageJson(t, packageJson).Imports, expectedImports)
-}
 
-func assertSpecifierMap(t *testing.T, field, packageJson string, actual, expected map[string][]string) {
-	t.Helper()
+	pkg := parsePackageJson(t, packageJson)
 
-	if (actual == nil) != (expected == nil) || len(actual) != len(expected) {
-		t.Errorf("ParsePackageJson(%q) expected %s %v, got %v", packageJson, field, expected, actual)
+	if (pkg.Imports == nil) != (expectedImports == nil) {
+		t.Errorf("ParsePackageJson(%q) expected imports %v, got %v", packageJson, expectedImports, pkg.Imports)
 		return
 	}
 
-	for specifier, expectedTargets := range expected {
+	if len(pkg.ImportPatterns) > 0 || len(pkg.Imports) != len(expectedImports) {
+		t.Errorf("ParsePackageJson(%q) expected exact imports %v, got %v patterns %v", packageJson, expectedImports, pkg.Imports, pkg.ImportPatterns)
+		return
+	}
+
+	for specifier, expectedTargets := range expectedImports {
 		// Order-sensitive: targets are sorted when parsed for deterministic resolution.
-		if !slices.Equal(actual[specifier], expectedTargets) {
-			t.Errorf("ParsePackageJson(%q) expected %s[%q] %q, got %q", packageJson, field, specifier, expectedTargets, actual[specifier])
+		if !slices.Equal(pkg.Imports[specifier], expectedTargets) {
+			t.Errorf("ParsePackageJson(%q) expected imports[%q] %q, got %q", packageJson, specifier, expectedTargets, pkg.Imports[specifier])
 		}
 	}
 }

--- a/language/js/resolve.go
+++ b/language/js/resolve.go
@@ -609,7 +609,7 @@ func (ts *typeScriptLang) findSubpathImport(c *config.Config, ix *resolve.RuleIn
 	// Collect all resolving targets. A conditional import may map different
 	// conditions to different targets, all of which are dependencies.
 	var results []resolve.FindResult
-	for _, target := range packageJson.Imports[imp] {
+	for _, target := range packageJson.ResolveImport(imp) {
 		if strings.HasPrefix(target, "./") {
 			// Files within the package
 			fileSpec := resolve.ImportSpec{Lang: LanguageName, Imp: path.Join(fromProject.Pkg(), target)}

--- a/language/js/tests/pnpm_workspace_imports/WORKSPACE
+++ b/language/js/tests/pnpm_workspace_imports/WORKSPACE
@@ -11,6 +11,9 @@
 #  * '#cond' conditionally mapping to separate directories per condition
 #    ('node', 'browser', 'default') resolves to all mapped targets
 #    (lib/pkg/index.ts -> //lib/pkg/cond_node + cond_browser + cond_default)
+#  * '#internal/*' subpath patterns map matching imports to the substituted
+#    target (lib/pkg/index.ts '#internal/util' -> //lib/pkg/internal)
 #  * the npm_package picks up targets generating internal 'imports' files
-#    (//lib/pkg/sub in //lib/pkg:pkg srcs)
+#    (//lib/pkg/sub in //lib/pkg:pkg srcs), except '*' wildcard entries
+#    which can not be statically enumerated (//lib/pkg/internal)
 workspace(name = "pnpm_workspace_imports")

--- a/language/js/tests/pnpm_workspace_imports/lib/pkg/BUILD.out
+++ b/language/js/tests/pnpm_workspace_imports/lib/pkg/BUILD.out
@@ -15,6 +15,7 @@ ts_project(
         "//lib/pkg/cond_browser",
         "//lib/pkg/cond_default",
         "//lib/pkg/cond_node",
+        "//lib/pkg/internal",
         "//lib/pkg/sub",
     ],
 )

--- a/language/js/tests/pnpm_workspace_imports/lib/pkg/index.ts
+++ b/language/js/tests/pnpm_workspace_imports/lib/pkg/index.ts
@@ -4,5 +4,7 @@ import { subId } from '#sub';
 import { otherId } from '#ext';
 // Conditional subpath import mapping conditions to separate directories.
 import { condId } from '#cond';
+// Subpath import matching a '*' pattern.
+import { internalId } from '#internal/util';
 
-export const id = () => subId() + otherId() + condId();
+export const id = () => subId() + otherId() + condId() + internalId();

--- a/language/js/tests/pnpm_workspace_imports/lib/pkg/internal/BUILD.out
+++ b/language/js/tests/pnpm_workspace_imports/lib/pkg/internal/BUILD.out
@@ -1,0 +1,6 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+ts_project(
+    name = "internal",
+    srcs = ["util.ts"],
+)

--- a/language/js/tests/pnpm_workspace_imports/lib/pkg/internal/util.ts
+++ b/language/js/tests/pnpm_workspace_imports/lib/pkg/internal/util.ts
@@ -1,0 +1,1 @@
+export const internalId = () => 'internal';

--- a/language/js/tests/pnpm_workspace_imports/lib/pkg/package.json
+++ b/language/js/tests/pnpm_workspace_imports/lib/pkg/package.json
@@ -11,7 +11,8 @@
       "node": "./cond_node/main.js",
       "browser": "./cond_browser/main.js",
       "default": "./cond_default/main.js"
-    }
+    },
+    "#internal/*": "./internal/*.js"
   },
   "dependencies": {
     "@lib/other": "workspace:*"


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
