### PR TITLE
refactor: remove unnecessary parallelization of jq/yq/regex/toml queries

### DIFF
--- a/language/orion/queries/BUILD.bazel
+++ b/language/orion/queries/BUILD.bazel
@@ -29,6 +29,5 @@ go_library(
         "@com_github_aspect_build_aspect_gazelle_common//treesitter",
         "@com_github_itchyny_gojq//:gojq",
         "@com_github_mikefarah_yq_v4//pkg/yqlib",
-        "@org_golang_x_sync//errgroup",
     ],
 )

--- a/language/orion/queries/jq.go
+++ b/language/orion/queries/jq.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/itchyny/gojq"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/aspect-build/aspect-gazelle/language/orion/plugin"
 )
@@ -18,30 +17,12 @@ func runJsonQueries(fileName string, sourceCode []byte, queries plugin.NamedQuer
 	}
 
 	results := make(plugin.QueryResults, len(queries))
-	var mu sync.Mutex
-
-	eg := errgroup.Group{}
-	eg.SetLimit(10)
-
 	for key, q := range queries {
-		// Capture loop variables for goroutine
-		key := key
-		q := q
-		eg.Go(func() error {
-			r, err := runJsonQuery(doc, q.(*plugin.JsonQuery).Query)
-			if err != nil {
-				return err
-			}
-
-			mu.Lock()
-			results[key] = r
-			mu.Unlock()
-			return nil
-		})
-	}
-
-	if err := eg.Wait(); err != nil {
-		return nil, err
+		r, err := runJsonQuery(doc, q.(*plugin.JsonQuery).Query)
+		if err != nil {
+			return nil, err
+		}
+		results[key] = r
 	}
 	return results, nil
 }

--- a/language/orion/queries/regex.go
+++ b/language/orion/queries/regex.go
@@ -2,34 +2,14 @@ package queries
 
 import (
 	"regexp"
-	"sync"
 
 	"github.com/aspect-build/aspect-gazelle/language/orion/plugin"
-	"golang.org/x/sync/errgroup"
 )
 
 func runRegexQueries(sourceCode []byte, queries plugin.NamedQueries) (plugin.QueryResults, error) {
 	results := make(plugin.QueryResults, len(queries))
-	var mu sync.Mutex
-
-	eg := errgroup.Group{}
-	eg.SetLimit(10)
-
 	for key, q := range queries {
-		// Capture loop variables for goroutine
-		key := key
-		q := q
-		eg.Go(func() error {
-			r := runRegexQuery(sourceCode, q.(*plugin.RegexQuery).ExpressionRe())
-			mu.Lock()
-			results[key] = r
-			mu.Unlock()
-			return nil
-		})
-	}
-
-	if err := eg.Wait(); err != nil {
-		return nil, err
+		results[key] = runRegexQuery(sourceCode, q.(*plugin.RegexQuery).ExpressionRe())
 	}
 	return results, nil
 }

--- a/language/orion/queries/toml.go
+++ b/language/orion/queries/toml.go
@@ -2,11 +2,9 @@ package queries
 
 import (
 	"bytes"
-	"sync"
 
 	"github.com/aspect-build/aspect-gazelle/language/orion/plugin"
 	"github.com/mikefarah/yq/v4/pkg/yqlib"
-	"golang.org/x/sync/errgroup"
 )
 
 func runTomlQueries(fileName string, sourceCode []byte, queries plugin.NamedQueries) (plugin.QueryResults, error) {
@@ -21,30 +19,12 @@ func runTomlQueries(fileName string, sourceCode []byte, queries plugin.NamedQuer
 	}
 
 	results := make(plugin.QueryResults, len(queries))
-	var mu sync.Mutex
-
-	eg := errgroup.Group{}
-	eg.SetLimit(10)
-
 	for key, q := range queries {
-		// Capture loop variables for goroutine
-		key := key
-		q := q
-		eg.Go(func() error {
-			r, err := runYamlQuery(node, q.(*plugin.TomlQuery).Query)
-			if err != nil {
-				return err
-			}
-
-			mu.Lock()
-			results[key] = r
-			mu.Unlock()
-			return nil
-		})
-	}
-
-	if err := eg.Wait(); err != nil {
-		return nil, err
+		r, err := runYamlQuery(node, q.(*plugin.TomlQuery).Query)
+		if err != nil {
+			return nil, err
+		}
+		results[key] = r
 	}
 	return results, nil
 }

--- a/language/orion/queries/yq.go
+++ b/language/orion/queries/yq.go
@@ -2,12 +2,10 @@ package queries
 
 import (
 	"bytes"
-	"sync"
 
 	BazelLog "github.com/aspect-build/aspect-gazelle/common/logger"
 	"github.com/aspect-build/aspect-gazelle/language/orion/plugin"
 	"github.com/mikefarah/yq/v4/pkg/yqlib"
-	"golang.org/x/sync/errgroup"
 )
 
 func runYamlQueries(fileName string, sourceCode []byte, queries plugin.NamedQueries) (plugin.QueryResults, error) {
@@ -22,30 +20,12 @@ func runYamlQueries(fileName string, sourceCode []byte, queries plugin.NamedQuer
 	}
 
 	results := make(plugin.QueryResults, len(queries))
-	var mu sync.Mutex
-
-	eg := errgroup.Group{}
-	eg.SetLimit(10)
-
 	for key, q := range queries {
-		// Capture loop variables for goroutine
-		key := key
-		q := q
-		eg.Go(func() error {
-			r, err := runYamlQuery(node, q.(*plugin.YamlQuery).Query)
-			if err != nil {
-				return err
-			}
-
-			mu.Lock()
-			results[key] = r
-			mu.Unlock()
-			return nil
-		})
-	}
-
-	if err := eg.Wait(); err != nil {
-		return nil, err
+		r, err := runYamlQuery(node, q.(*plugin.YamlQuery).Query)
+		if err != nil {
+			return nil, err
+		}
+		results[key] = r
 	}
 	return results, nil
 }


### PR DESCRIPTION
The overlap of error groups and per-file parallelization causes confusion and potentially perf/io issues.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
