### PR TITLE
perf: add resuse of buffers when reading source files

### DIFF
--- a/common/cache/BUILD.bazel
+++ b/common/cache/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "disk.go",
         "filecompute.go",
         "noop.go",
+        "readfile.go",
         "watch.go",
     ],
     importpath = "github.com/aspect-build/aspect-gazelle/common/cache",

--- a/common/cache/disk.go
+++ b/common/cache/disk.go
@@ -123,10 +123,11 @@ func (c *diskCache) write() {
 }
 
 func (c *diskCache) LoadOrStoreFile(root, p, key string, loader FileCompute) (any, bool, error) {
-	content, err := os.ReadFile(path.Join(root, p))
+	content, release, err := readFile(path.Join(root, p))
 	if err != nil {
 		return nil, false, err
 	}
+	defer release()
 
 	contentHash := computeCacheKey(content)
 

--- a/common/cache/disk_test.go
+++ b/common/cache/disk_test.go
@@ -1,10 +1,46 @@
 package cache
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+// readFile must return identical bytes across sizes (including empty files and
+// files larger than a recycled buffer's capacity), and release() must always be
+// safe to call. Running several sizes in sequence also exercises buffer reuse
+// from the pool, including growing a smaller pooled buffer for a larger file.
+func TestReadFile(t *testing.T) {
+	dir := t.TempDir()
+
+	sizes := map[string]int{
+		"empty": 0,
+		"small": 64,
+		"large": 64 * 1024,
+	}
+	for name, size := range sizes {
+		t.Run(name, func(t *testing.T) {
+			want := make([]byte, size)
+			for i := range want {
+				want[i] = byte('a' + i%26)
+			}
+			p := filepath.Join(dir, name)
+			if err := os.WriteFile(p, want, 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			got, release, err := readFile(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer release()
+			if !bytes.Equal(got, want) {
+				t.Errorf("size %d: content mismatch (got %d bytes)", size, len(got))
+			}
+		})
+	}
+}
 
 func writeTestFile(t *testing.T, dir, name, content string) {
 	t.Helper()

--- a/common/cache/filecompute.go
+++ b/common/cache/filecompute.go
@@ -150,10 +150,11 @@ func (c *FileComputeCache) LoadOrStoreFile(root, p, key string, loader FileCompu
 		}
 	}
 
-	content, err := os.ReadFile(path.Join(root, p))
+	content, release, err := readFile(path.Join(root, p))
 	if err != nil {
 		return nil, false, err
 	}
+	defer release()
 	return c.loadOrStore(p, key, content, loader)
 }
 

--- a/common/cache/noop.go
+++ b/common/cache/noop.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"os"
 	"path"
 )
 
@@ -12,10 +11,11 @@ var noop Cache = &noopCache{}
 type noopCache struct{}
 
 func (c *noopCache) LoadOrStoreFile(root, p, key string, loader FileCompute) (any, bool, error) {
-	content, err := os.ReadFile(path.Join(root, p))
+	content, release, err := readFile(path.Join(root, p))
 	if err != nil {
 		return nil, false, err
 	}
+	defer release()
 
 	result, err := loader(p, content)
 	return result, false, err

--- a/common/cache/readfile.go
+++ b/common/cache/readfile.go
@@ -1,0 +1,56 @@
+package cache
+
+import (
+	"io"
+	"os"
+	"sync"
+)
+
+// bufPool recycles file-read buffers, turning per-file read allocation (the
+// dominant heap churn) into a small set of reused buffers. We store *[]byte, not
+// []byte, to avoid boxing the slice header on every Put.
+var bufPool = sync.Pool{New: func() any { return new([]byte) }}
+
+// maxPooledBuffer caps pooled capacity: buffers grown past this by a large file
+// are dropped on release rather than pinned for later small reads.
+const maxPooledBuffer = 1 << 20 // 1 MiB
+
+// readFile reads the file into a pooled buffer, returning its contents and a
+// release func the caller MUST call once done. The bytes are only valid until
+// release(); callers must copy out anything they retain (the parsers here do).
+func readFile(name string) (content []byte, release func(), err error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, nil, err
+	}
+	size := int(fi.Size())
+
+	bufp := bufPool.Get().(*[]byte)
+	buf := *bufp
+	if cap(buf) < size {
+		buf = make([]byte, size)
+	} else {
+		buf = buf[:size]
+	}
+
+	// Return to the pool unless it grew too large to keep.
+	release = func() {
+		if cap(buf) <= maxPooledBuffer {
+			*bufp = buf
+			bufPool.Put(bufp)
+		}
+	}
+
+	if _, err := io.ReadFull(f, buf); err != nil {
+		release()
+		return nil, nil, err
+	}
+
+	return buf, release, nil
+}


### PR DESCRIPTION
Greatly reduced GC churn when reading many files, reduces GC. On high-cpu machines will not lead to any runtime reductions.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
