### PR TITLE
fix(common): check bufio.Scanner error when reading .bazelignore

### DIFF
--- a/common/bazel/BUILD.bazel
+++ b/common/bazel/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "bazel",
@@ -12,4 +12,10 @@ go_library(
         "//bazel/workspace",
         "//logger",
     ],
+)
+
+go_test(
+    name = "bazel_test",
+    srcs = ["bazelignore_test.go"],
+    embed = [":bazel"],
 )

--- a/common/bazel/bazelignore.go
+++ b/common/bazel/bazelignore.go
@@ -62,5 +62,9 @@ func loadBazelIgnore(repoRoot string) ([]string, error) {
 		excludes = append(excludes, ignore)
 	}
 
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf(".bazelignore exists but couldn't be read: %v", err)
+	}
+
 	return excludes, nil
 }

--- a/common/bazel/bazelignore_test.go
+++ b/common/bazel/bazelignore_test.go
@@ -1,0 +1,41 @@
+package bazel
+
+import (
+	"os"
+	"path"
+	"strings"
+	"testing"
+)
+
+func TestLoadBazelIgnore(t *testing.T) {
+	dir := t.TempDir()
+	content := "# comment\nfoo\n\n./bar/baz\nstar-*-glob\n"
+	if err := os.WriteFile(path.Join(dir, ".bazelignore"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	excludes, err := loadBazelIgnore(dir)
+	if err != nil {
+		t.Fatalf("loadBazelIgnore returned error: %v", err)
+	}
+	if len(excludes) != 2 || excludes[0] != "foo" || excludes[1] != "bar/baz" {
+		t.Errorf("unexpected excludes: %v", excludes)
+	}
+}
+
+func TestLoadBazelIgnoreScannerError(t *testing.T) {
+	dir := t.TempDir()
+
+	// A line longer than bufio.MaxScanTokenSize (64KB) causes the scanner to
+	// fail mid-file. The error must be reported, not silently truncate the
+	// ignore list.
+	content := "before\n" + strings.Repeat("x", 1024*1024) + "\nafter\n"
+	if err := os.WriteFile(path.Join(dir, ".bazelignore"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := loadBazelIgnore(dir)
+	if err == nil {
+		t.Fatal("expected an error for a .bazelignore line exceeding the scanner buffer, got nil")
+	}
+}


### PR DESCRIPTION
A scan failure (e.g. a line exceeding bufio.MaxScanTokenSize) previously returned a silently truncated ignore list; now the error is propagated.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
