### PR TITLE
fix: RenderTsConfigName mangled names via TrimRight instead of TrimSuffix

### DIFF
--- a/language/js/config.go
+++ b/language/js/config.go
@@ -600,7 +600,7 @@ func (c *JsGazelleConfig) RenderTsProtoLibraryName(protoLibraryName string) stri
 }
 
 func (c *JsGazelleConfig) RenderTsConfigName(tsconfigName string) string {
-	return strings.ReplaceAll(strings.TrimRight(path.Base(tsconfigName), ".json"), ".", "_")
+	return strings.ReplaceAll(strings.TrimSuffix(path.Base(tsconfigName), ".json"), ".", "_")
 }
 
 // Returns the ts_project target name by performing all substitutions.

--- a/language/js/config_test.go
+++ b/language/js/config_test.go
@@ -6,6 +6,25 @@ import (
 	"testing"
 )
 
+func TestRenderTsConfigName(t *testing.T) {
+	c := newRootConfig()
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		{in: "tsconfig.json", want: "tsconfig"},
+		// Stems ending in characters from {'.','j','s','o','n'} must not be mangled.
+		{in: "options.json", want: "options"},
+		{in: "common.json", want: "common"},
+		{in: "tsconfig.options.json", want: "tsconfig_options"},
+		{in: "some/dir/options.json", want: "options"},
+	} {
+		if got := c.RenderTsConfigName(tc.in); got != tc.want {
+			t.Errorf("RenderTsConfigName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestAddTargetGlobNormalization(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/language/js/tests/tsconfig_multiple_configs/name_trim/BUILD.in
+++ b/language/js/tests/tsconfig_multiple_configs/name_trim/BUILD.in
@@ -1,0 +1,5 @@
+# Test: a tsconfig file whose basename stem ends in characters from the set
+# {'.', 'j', 's', 'o', 'n'} ("options" ends in 's'). The rendered ts_config
+# rule name must be "tsconfig_options", trimming only the ".json" suffix —
+# not "tsconfig_opti" from trimming the trailing character set.
+# gazelle:js_tsconfig_file tsconfig.options.json

--- a/language/js/tests/tsconfig_multiple_configs/name_trim/BUILD.out
+++ b/language/js/tests/tsconfig_multiple_configs/name_trim/BUILD.out
@@ -1,0 +1,19 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+
+# Test: a tsconfig file whose basename stem ends in characters from the set
+# {'.', 'j', 's', 'o', 'n'} ("options" ends in 's'). The rendered ts_config
+# rule name must be "tsconfig_options", trimming only the ".json" suffix —
+# not "tsconfig_opti" from trimming the trailing character set.
+# gazelle:js_tsconfig_file tsconfig.options.json
+
+ts_project(
+    name = "name_trim",
+    srcs = ["main.ts"],
+    tsconfig = ":tsconfig_options",
+)
+
+ts_config(
+    name = "tsconfig_options",
+    src = "tsconfig.options.json",
+    visibility = [":__subpackages__"],
+)

--- a/language/js/tests/tsconfig_multiple_configs/name_trim/main.ts
+++ b/language/js/tests/tsconfig_multiple_configs/name_trim/main.ts
@@ -1,0 +1,1 @@
+export const foo = 1;

--- a/language/js/tests/tsconfig_multiple_configs/name_trim/tsconfig.options.json
+++ b/language/js/tests/tsconfig_multiple_configs/name_trim/tsconfig.options.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}


### PR DESCRIPTION
strings.TrimRight strips any trailing characters from the set {'.','j','s','o','n'}, so tsconfig basenames whose stem ends in those characters (e.g. options.json -> opti) were mangled. Use strings.TrimSuffix to remove only the literal .json extension.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
