### PR TITLE
fix: parseArgs returned global flag.Args() instead of the local FlagSet's args

### DIFF
--- a/runner/bin/cli/BUILD.bazel
+++ b/runner/bin/cli/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "cli_lib",
@@ -21,4 +21,11 @@ go_binary(
     embed = [":cli_lib"],
     tags = ["supports_incremental_build_protocol"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "cli_test",
+    srcs = ["main_test.go"],
+    embed = [":cli_lib"],
+    deps = ["//:runner"],
 )

--- a/runner/bin/cli/main.go
+++ b/runner/bin/cli/main.go
@@ -101,7 +101,7 @@ configure:
 		os.Exit(1)
 	}
 
-	return *mode, languages, plugins, flag.Args()
+	return *mode, languages, plugins, args.Args()
 }
 
 // Simplified Aspect CLI config file parser

--- a/runner/bin/cli/main_test.go
+++ b/runner/bin/cli/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/aspect-build/aspect-gazelle/runner"
+)
+
+func TestParseArgsPositionalArgs(t *testing.T) {
+	// parseArgs reads the config file relative to the working directory.
+	dir := t.TempDir()
+	configYaml := `configure:
+  languages:
+    go: true
+  plugins:
+    - my/plugin.star
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(configYaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	// parseArgs parses os.Args[1:].
+	origArgs := os.Args
+	t.Cleanup(func() { os.Args = origArgs })
+	os.Args = []string{"configure", "--mode=fix", "--config=config.yaml", "foo/bar", "baz"}
+
+	mode, languages, plugins, args := parseArgs()
+
+	if mode != runner.Fix {
+		t.Errorf("mode: got %q, want %q", mode, runner.Fix)
+	}
+	if want := []string{"go"}; !reflect.DeepEqual(languages, want) {
+		t.Errorf("languages: got %v, want %v", languages, want)
+	}
+	if want := []string{"my/plugin.star"}; !reflect.DeepEqual(plugins, want) {
+		t.Errorf("plugins: got %v, want %v", plugins, want)
+	}
+
+	// Positional arguments after the flags must be returned.
+	if want := []string{"foo/bar", "baz"}; !reflect.DeepEqual(args, want) {
+		t.Errorf("args: got %v, want %v", args, want)
+	}
+}


### PR DESCRIPTION
parseArgs parsed flags on a local flag.FlagSet but returned the never-parsed global flag package's Args(), silently dropping positional arguments such as 'cli --mode=fix --config=config.yaml foo/bar baz'. Reproduced by the new TestParseArgsPositionalArgs.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
