### PR TITLE
perf: use map[string]struct{} for the Node builtin-module set

### DIFF
--- a/language/js/node/BUILD.bazel
+++ b/language/js/node/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_aspect_build_aspect_gazelle_common//logger",
-        "@com_github_emirpasic_gods_v2//sets/treeset",
         "@com_github_goexlib_jsonc//:jsonc",
     ],
 )
@@ -23,6 +22,7 @@ go_test(
     srcs = [
         "package_test.go",
         "paths_test.go",
+        "std_modules_test.go",
     ],
     embed = [":node"],
 )

--- a/language/js/node/std_modules.go
+++ b/language/js/node/std_modules.go
@@ -3,8 +3,6 @@ package gazelle
 import (
 	_ "embed"
 	"strings"
-
-	"github.com/emirpasic/gods/v2/sets/treeset"
 )
 
 //go:embed std_modules.list
@@ -12,16 +10,20 @@ var nativeModulesJson []byte
 
 var nativeModulesSet = createNativeModulesSet()
 
-func createNativeModulesSet() *treeset.Set[string] {
-	set := treeset.NewWith(strings.Compare)
+func createNativeModulesSet() map[string]struct{} {
+	set := make(map[string]struct{})
 
 	for m := range strings.SplitSeq(strings.TrimSpace(string(nativeModulesJson)), "\n") {
-		set.Add(m)
+		set[m] = struct{}{}
 	}
 
 	return set
 }
 
 func IsNodeImport(imprt string) bool {
-	return strings.HasPrefix(imprt, "node:") || nativeModulesSet.Contains(imprt)
+	if strings.HasPrefix(imprt, "node:") {
+		return true
+	}
+	_, ok := nativeModulesSet[imprt]
+	return ok
 }

--- a/language/js/node/std_modules_test.go
+++ b/language/js/node/std_modules_test.go
@@ -1,0 +1,40 @@
+package gazelle
+
+import (
+	"testing"
+)
+
+func TestIsNodeImport(t *testing.T) {
+	builtins := []string{
+		"fs",
+		"fs/promises",
+		"path",
+		"assert",
+		"assert/strict",
+		"child_process",
+		"util",
+		// "node:" prefixed imports are always builtins
+		"node:fs",
+		"node:path",
+		"node:test",
+	}
+	for _, m := range builtins {
+		if !IsNodeImport(m) {
+			t.Errorf("IsNodeImport(%q) = false, want true", m)
+		}
+	}
+
+	nonBuiltins := []string{
+		"",
+		"react",
+		"@scope/pkg",
+		"./fs",
+		"fs2",
+		"lodash/fp",
+	}
+	for _, m := range nonBuiltins {
+		if IsNodeImport(m) {
+			t.Errorf("IsNodeImport(%q) = true, want false", m)
+		}
+	}
+}


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
