### PR TITLE
fix: remove diskCache.file shadowing of embedded FileComputeCache.file

### DIFF
--- a/common/cache/disk.go
+++ b/common/cache/disk.go
@@ -17,10 +17,8 @@ import (
  * (see VerifyCacheVersion).
  */
 func NewDiskCache(cacheFilePath string) Cache {
-	c := &diskCache{
-		FileComputeCache: NewFileComputeCache(),
-		file:             cacheFilePath,
-	}
+	c := &diskCache{FileComputeCache: NewFileComputeCache()}
+	c.file = cacheFilePath
 	c.read()
 	return c
 }
@@ -40,10 +38,8 @@ func init() {
 var _ Cache = (*diskCache)(nil)
 
 type diskCache struct {
+	// FileComputeCache, including the `file` field where the cache is persisted.
 	*FileComputeCache
-
-	// Where the cache is persisted to disk.
-	file string
 
 	// Maps file path → content hash, used to detect stale entries.
 	contentHashes sync.Map

--- a/common/cache/disk_test.go
+++ b/common/cache/disk_test.go
@@ -162,6 +162,21 @@ func TestDiskCache_MultipleOpsPerFile(t *testing.T) {
 	}
 }
 
+// Guards against diskCache re-declaring a `file` field that shadows the
+// embedded FileComputeCache.file: with two same-named fields, `c.file`
+// resolves to the shallow one and the embedded FileComputeCache's path is
+// left permanently empty. There must be exactly one live `file` field, on
+// FileComputeCache, holding the configured path.
+func TestDiskCache_FilePathOnEmbeddedFileComputeCache(t *testing.T) {
+	dir := t.TempDir()
+	cacheFile := filepath.Join(dir, "cache")
+
+	c := NewDiskCache(cacheFile).(*diskCache)
+	if c.FileComputeCache.file != cacheFile {
+		t.Errorf("FileComputeCache.file = %q, want %q (diskCache must not shadow the embedded field)", c.FileComputeCache.file, cacheFile)
+	}
+}
+
 // Entries written to disk are available after constructing a new cache instance.
 func TestDiskCache_Persistence(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
`diskCache` declared its own `file` field with the same name as the embedded `FileComputeCache.file`, so the embedded field was permanently empty. Keep the single field on `FileComputeCache` and assign it after construction, since a promoted unexported field cannot be set via a composite-literal key.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
