### PR TITLE
fix(orion): ErrorStr dropped the caller-provided error context

### DIFF
--- a/language/orion/starlark/utils/err.go
+++ b/language/orion/starlark/utils/err.go
@@ -9,10 +9,16 @@ import (
 )
 
 func ErrorStr(pre string, err error) string {
+	var msg string
 	if ee, isEvalError := err.(*starlark.EvalError); isEvalError {
-		return evalErrorBacktrace(ee)
+		msg = evalErrorBacktrace(ee)
+	} else {
+		msg = err.Error()
 	}
-	return err.Error()
+	if pre == "" {
+		return msg
+	}
+	return pre + ": " + msg
 }
 
 // Modified version of starlark.EvalError.Backtrace(), starlark.CallStack.String() ...

--- a/language/orion/starlark/utils/util_test.go
+++ b/language/orion/starlark/utils/util_test.go
@@ -1,6 +1,8 @@
 package starlark
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	"go.starlark.net/starlark"
@@ -145,6 +147,45 @@ func TestReadWrite(t *testing.T) {
 		l2, isBool := l.Index(2).(starlark.Bool)
 		if !isBool || a[2] != (l2.Truth() == starlark.True) {
 			t.Errorf("Expected %v to be Bool", l2)
+		}
+	})
+}
+
+func TestErrorStr(t *testing.T) {
+	t.Run("plain error includes pre context", func(t *testing.T) {
+		s := ErrorStr("Failed to invoke myplugin:Prepare()", errors.New("boom"))
+		if !strings.Contains(s, "Failed to invoke myplugin:Prepare()") {
+			t.Errorf("Expected pre context in %q", s)
+		}
+		if !strings.Contains(s, "boom") {
+			t.Errorf("Expected error message in %q", s)
+		}
+	})
+
+	t.Run("EvalError includes pre context and backtrace", func(t *testing.T) {
+		_, err := starlark.ExecFile(&starlark.Thread{}, "test.star", "fail(\"boom\")", nil)
+		if err == nil {
+			t.Fatal("Expected an error")
+		}
+		if _, isEvalError := err.(*starlark.EvalError); !isEvalError {
+			t.Fatalf("Expected *starlark.EvalError, got %T", err)
+		}
+
+		s := ErrorStr("Failed to invoke myplugin:Analyze()", err)
+		if !strings.Contains(s, "Failed to invoke myplugin:Analyze()") {
+			t.Errorf("Expected pre context in %q", s)
+		}
+		if !strings.Contains(s, "boom") {
+			t.Errorf("Expected error message in %q", s)
+		}
+		if !strings.Contains(s, "Traceback") {
+			t.Errorf("Expected backtrace in %q", s)
+		}
+	})
+
+	t.Run("empty pre returns error message only", func(t *testing.T) {
+		if s := ErrorStr("", errors.New("boom")); s != "boom" {
+			t.Errorf("Expected %q, got %q", "boom", s)
 		}
 	})
 }

--- a/language/orion/tests/starzelle/bad-sourceglob-exclude/expectedStdout.txt
+++ b/language/orion/tests/starzelle/bad-sourceglob-exclude/expectedStdout.txt
@@ -1,3 +1,3 @@
-Error in aspect.SourceGlobs: exclude: invalid glob pattern: **/[
+Failed to invoke bad-sourceglob-exclude-test:Prepare(): Error in aspect.SourceGlobs: exclude: invalid glob pattern: **/[
 Traceback (most recent call last):
   bad-sourceglob-exclude/bad-sourceglob-exclude.axl:4:37: in lambda

--- a/language/orion/tests/starzelle/bad-sourceglob-kwarg/expectedStdout.txt
+++ b/language/orion/tests/starzelle/bad-sourceglob-kwarg/expectedStdout.txt
@@ -1,3 +1,3 @@
-Error in aspect.SourceGlobs: unexpected keyword argument "foobar"
+Failed to invoke bad-sourceglob-kwarg-test:Prepare(): Error in aspect.SourceGlobs: unexpected keyword argument "foobar"
 Traceback (most recent call last):
   bad-sourceglob-kwarg/bad-sourceglob-kwarg.axl:4:37: in lambda

--- a/language/orion/tests/starzelle/bad-sourceglob-no-include/expectedStdout.txt
+++ b/language/orion/tests/starzelle/bad-sourceglob-no-include/expectedStdout.txt
@@ -1,3 +1,3 @@
-Error in aspect.SourceGlobs: at least one include glob pattern is required
+Failed to invoke bad-sourceglob-no-include-test:Prepare(): Error in aspect.SourceGlobs: at least one include glob pattern is required
 Traceback (most recent call last):
   bad-sourceglob-no-include/bad-sourceglob-no-include.axl:4:37: in lambda

--- a/language/orion/tests/starzelle/bad-sourceglob/expectedStdout.txt
+++ b/language/orion/tests/starzelle/bad-sourceglob/expectedStdout.txt
@@ -1,3 +1,3 @@
-Error in aspect.SourceGlobs: invalid glob pattern: **/[
+Failed to invoke bad-sourceglob-test:Prepare(): Error in aspect.SourceGlobs: invalid glob pattern: **/[
 Traceback (most recent call last):
   bad-sourceglob/bad-sourceglob.axl:4:37: in lambda

--- a/language/orion/tests/starzelle/bad_prepareresult/expectedStdout.txt
+++ b/language/orion/tests/starzelle/bad_prepareresult/expectedStdout.txt
@@ -1,3 +1,3 @@
-Error in aspect.SourceGlobs: expected string, got starlark.Bool
+Failed to invoke bad_prepareresult-bool:Prepare(): Error in aspect.SourceGlobs: expected string, got starlark.Bool
 Traceback (most recent call last):
   bad_prepareresult/bad-prep.axl:4:37: in lambda

--- a/language/orion/tests/starzelle/fail/expectedStdout.txt
+++ b/language/orion/tests/starzelle/fail/expectedStdout.txt
@@ -1,3 +1,3 @@
-Error in fail: fail: no prepare for you!
+Failed to invoke errors:Prepare(): Error in fail: fail: no prepare for you!
 Traceback (most recent call last):
   fail/fail.axl:3:29: in lambda

--- a/language/orion/tests/starzelle/imports-ancestor-multiple/expectedStdout.txt
+++ b/language/orion/tests/starzelle/imports-ancestor-multiple/expectedStdout.txt
@@ -1,3 +1,3 @@
-Error in aspect.Import: import cannot be both ancestor and multiple
+Failed to invoke ancestor-multiple:DeclareTargets(): Error in aspect.Import: import cannot be both ancestor and multiple
 Traceback (most recent call last):
   imports-ancestor-multiple/conflict.axl:14:30: in declare

--- a/language/orion/tests/starzelle/is-local-unknown/expectedStdout.txt
+++ b/language/orion/tests/starzelle/is-local-unknown/expectedStdout.txt
@@ -1,3 +1,3 @@
-Error in is_local: no property named: no-such-property
+Failed to invoke is-local-unknown:Prepare(): Error in is_local: no property named: no-such-property
 Traceback (most recent call last):
   is-local-unknown/unknown.axl:5:28: in prepare

--- a/language/orion/tests/starzelle/query-bad-content-filter/expectedStdout.txt
+++ b/language/orion/tests/starzelle/query-bad-content-filter/expectedStdout.txt
@@ -1,3 +1,3 @@
-Error in aspect.RawQuery: `content_filter` is not a valid regex "(": error parsing regexp: missing closing ): `(`
+Failed to invoke bad-content-filter-test:Prepare(): Error in aspect.RawQuery: `content_filter` is not a valid regex "(": error parsing regexp: missing closing ): `(`
 Traceback (most recent call last):
   query-bad-content-filter/bad-content-filter.axl:8:33: in lambda

--- a/language/orion/tests/starzelle/query-bad-def/expectedStdout.txt
+++ b/language/orion/tests/starzelle/query-bad-def/expectedStdout.txt
@@ -1,3 +1,3 @@
-Error in aspect.RawQuery: RawQuery: unexpected keyword argument "f"
+Failed to invoke bad-test:Prepare(): Error in aspect.RawQuery: RawQuery: unexpected keyword argument "f"
 Traceback (most recent call last):
   query-bad-def/bad.axl:9:33: in lambda

--- a/language/orion/tests/starzelle/query-bad-glob/expectedStdout.txt
+++ b/language/orion/tests/starzelle/query-bad-glob/expectedStdout.txt
@@ -1,3 +1,3 @@
-Error in aspect.RawQuery: invalid glob pattern: [
+Failed to invoke bad-glob-test:Prepare(): Error in aspect.RawQuery: invalid glob pattern: [
 Traceback (most recent call last):
   query-bad-glob/bad-glob.axl:8:33: in lambda

--- a/language/orion/tests/starzelle/query-bad-regex/expectedStdout.txt
+++ b/language/orion/tests/starzelle/query-bad-regex/expectedStdout.txt
@@ -1,3 +1,3 @@
-Error in aspect.RegexQuery: error parsing regexp: missing closing ): `(`
+Failed to invoke bad-regex-test:Prepare(): Error in aspect.RegexQuery: error parsing regexp: missing closing ): `(`
 Traceback (most recent call last):
   query-bad-regex/bad-regex.axl:8:35: in lambda


### PR DESCRIPTION
`ErrorStr` ignored its `pre` parameter, so plugin/method context passed by callers (e.g. `"Failed to invoke <plugin>:Prepare()"`) never appeared in error output; now prefixed as `"<pre>: <error>"` in both branches.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
