### PR TITLE
fix: String() printed maps.Keys iterator address instead of the keys

### DIFF
--- a/language/orion/plugin/plugin.star.go
+++ b/language/orion/plugin/plugin.star.go
@@ -181,7 +181,7 @@ func (t TargetSourceList) Index(i int) starlark.Value {
 var _ starlark.Value = (*TargetSources)(nil)
 
 func (c TargetSources) String() string {
-	return fmt.Sprintf("DeclareTargetsContext.Sources{%v}", maps.Keys(c))
+	return fmt.Sprintf("DeclareTargetsContext.Sources{%v}", slices.Sorted(maps.Keys(c)))
 }
 func (c TargetSources) Type() string { return "DeclareTargetsContext.Sources" }
 func (c TargetSources) Freeze()      {}

--- a/language/orion/plugin/queries.star.go
+++ b/language/orion/plugin/queries.star.go
@@ -268,7 +268,7 @@ func (nq NamedQueries) Get(k starlark.Value) (v starlark.Value, found bool, err 
 	r, found := nq[key]
 
 	if !found {
-		return nil, false, fmt.Errorf("no query named %q, queries: %v", key, maps.Keys(nq))
+		return nil, false, fmt.Errorf("no query named %q, queries: %v", key, slices.Sorted(maps.Keys(nq)))
 	}
 
 	// Pure primitive query results


### PR DESCRIPTION
`TargetSources.String()` and the `NamedQueries.Get()` error message passed the `maps.Keys` iterator (a func value) to fmt %v; materialize with `slices.Sorted` for readable, deterministic key lists.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
