### PR TITLE
refactor: remove smacker/go-tree-sitter from treesitter module api

### DIFF
--- a/common/treesitter/filters_test.go
+++ b/common/treesitter/filters_test.go
@@ -9,7 +9,7 @@ import (
 	golang "github.com/aspect-build/aspect-gazelle/treesitter/golang"
 )
 
-var goLang = treesitter.NewLanguageFromSitter(treesitter.Go, golang.NewLanguage())
+var goLang = treesitter.NewLanguage(treesitter.Go, golang.LanguagePtr())
 
 func mustParseGo(t *testing.T, src string) treesitter.AST {
 	t.Helper()

--- a/common/treesitter/parser.go
+++ b/common/treesitter/parser.go
@@ -67,13 +67,6 @@ func NewLanguage(grammar LanguageGrammar, langPtr unsafe.Pointer) Language {
 	}
 }
 
-func NewLanguageFromSitter(grammar LanguageGrammar, lang *sitter.Language) Language {
-	return &treeLanguage{
-		grammar: grammar,
-		lang:    lang,
-	}
-}
-
 type treeLanguage struct {
 	grammar LanguageGrammar
 	lang    *sitter.Language

--- a/language/kotlin/parser/parser.go
+++ b/language/kotlin/parser/parser.go
@@ -62,7 +62,7 @@ func (p *treeSitterParser) Parse(filePath string, sourceCode []byte) (*ParseResu
 
 	var errs []error
 
-	lang := treeutils.NewLanguageFromSitter(treeutils.Kotlin, kotlin.NewLanguage())
+	lang := treeutils.NewLanguage(treeutils.Kotlin, kotlin.LanguagePtr())
 	tree, err := treeutils.ParseSourceCode(lang, filePath, sourceCode)
 	if err != nil {
 		errs = append(errs, err)

--- a/language/orion/queries/ast.go
+++ b/language/orion/queries/ast.go
@@ -62,27 +62,27 @@ func toTreeLanguage(fileName string, queries plugin.NamedQueries) treesitter.Lan
 
 	switch lang {
 	case treesitter.Go:
-		return treesitter.NewLanguageFromSitter(treesitter.Go, golang.NewLanguage())
+		return treesitter.NewLanguage(treesitter.Go, golang.LanguagePtr())
 	case treesitter.HCL:
-		return treesitter.NewLanguageFromSitter(treesitter.HCL, hcl.NewLanguage())
+		return treesitter.NewLanguage(treesitter.HCL, hcl.LanguagePtr())
 	case treesitter.Java:
-		return treesitter.NewLanguageFromSitter(treesitter.Java, java.NewLanguage())
+		return treesitter.NewLanguage(treesitter.Java, java.LanguagePtr())
 	case treesitter.JSON:
-		return treesitter.NewLanguageFromSitter(treesitter.JSON, json.NewLanguage())
+		return treesitter.NewLanguage(treesitter.JSON, json.LanguagePtr())
 	case treesitter.Kotlin:
-		return treesitter.NewLanguageFromSitter(treesitter.Kotlin, kotlin.NewLanguage())
+		return treesitter.NewLanguage(treesitter.Kotlin, kotlin.LanguagePtr())
 	case treesitter.Python:
-		return treesitter.NewLanguageFromSitter(treesitter.Python, python.NewLanguage())
+		return treesitter.NewLanguage(treesitter.Python, python.LanguagePtr())
 	case treesitter.Ruby:
-		return treesitter.NewLanguageFromSitter(treesitter.Ruby, ruby.NewLanguage())
+		return treesitter.NewLanguage(treesitter.Ruby, ruby.LanguagePtr())
 	case treesitter.Rust:
-		return treesitter.NewLanguageFromSitter(treesitter.Rust, rust.NewLanguage())
+		return treesitter.NewLanguage(treesitter.Rust, rust.LanguagePtr())
 	case treesitter.Starlark:
-		return treesitter.NewLanguageFromSitter(treesitter.Starlark, starlark.NewLanguage())
+		return treesitter.NewLanguage(treesitter.Starlark, starlark.LanguagePtr())
 	case treesitter.Typescript:
-		return treesitter.NewLanguageFromSitter(treesitter.Typescript, typescript.NewLanguage())
+		return treesitter.NewLanguage(treesitter.Typescript, typescript.LanguagePtr())
 	case treesitter.TypescriptX:
-		return treesitter.NewLanguageFromSitter(treesitter.TypescriptX, tsx.NewLanguage())
+		return treesitter.NewLanguage(treesitter.TypescriptX, tsx.LanguagePtr())
 	}
 
 	BazelLog.Fatalf("Unknown LanguageGrammar %q", lang)

--- a/treesitter/golang/BUILD.bazel
+++ b/treesitter/golang/BUILD.bazel
@@ -10,5 +10,4 @@ go_library(
     copts = ["-Iexternal/*tree-sitter-go"],
     importpath = "github.com/aspect-build/aspect-gazelle/treesitter/golang",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_smacker_go_tree_sitter//:go-tree-sitter"],
 )

--- a/treesitter/golang/binding.go
+++ b/treesitter/golang/binding.go
@@ -3,12 +3,10 @@ package golang
 //#include "tree_sitter/parser.h"
 //TSLanguage *tree_sitter_go();
 import "C"
-import (
-	"unsafe"
+import "unsafe"
 
-	sitter "github.com/smacker/go-tree-sitter"
-)
-
-func NewLanguage() *sitter.Language {
-	return sitter.NewLanguage(unsafe.Pointer(C.tree_sitter_go()))
+// LanguagePtr returns the raw tree-sitter grammar (`const TSLanguage *`),
+// for use with a parsing backend such as common/treesitter NewLanguage().
+func LanguagePtr() unsafe.Pointer {
+	return unsafe.Pointer(C.tree_sitter_go())
 }

--- a/treesitter/hcl/BUILD.bazel
+++ b/treesitter/hcl/BUILD.bazel
@@ -10,5 +10,4 @@ go_library(
     copts = ["-Iexternal/*tree-sitter-hcl"],
     importpath = "github.com/aspect-build/aspect-gazelle/treesitter/hcl",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_smacker_go_tree_sitter//:go-tree-sitter"],
 )

--- a/treesitter/hcl/binding.go
+++ b/treesitter/hcl/binding.go
@@ -3,12 +3,10 @@ package hcl
 //#include "tree_sitter/parser.h"
 //TSLanguage *tree_sitter_hcl();
 import "C"
-import (
-	"unsafe"
+import "unsafe"
 
-	sitter "github.com/smacker/go-tree-sitter"
-)
-
-func NewLanguage() *sitter.Language {
-	return sitter.NewLanguage(unsafe.Pointer(C.tree_sitter_hcl()))
+// LanguagePtr returns the raw tree-sitter grammar (`const TSLanguage *`),
+// for use with a parsing backend such as common/treesitter NewLanguage().
+func LanguagePtr() unsafe.Pointer {
+	return unsafe.Pointer(C.tree_sitter_hcl())
 }

--- a/treesitter/java/BUILD.bazel
+++ b/treesitter/java/BUILD.bazel
@@ -10,5 +10,4 @@ go_library(
     copts = ["-Iexternal/*tree-sitter-java"],
     importpath = "github.com/aspect-build/aspect-gazelle/treesitter/java",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_smacker_go_tree_sitter//:go-tree-sitter"],
 )

--- a/treesitter/java/binding.go
+++ b/treesitter/java/binding.go
@@ -3,12 +3,10 @@ package java
 //#include "tree_sitter/parser.h"
 //TSLanguage *tree_sitter_java();
 import "C"
-import (
-	"unsafe"
+import "unsafe"
 
-	sitter "github.com/smacker/go-tree-sitter"
-)
-
-func NewLanguage() *sitter.Language {
-	return sitter.NewLanguage(unsafe.Pointer(C.tree_sitter_java()))
+// LanguagePtr returns the raw tree-sitter grammar (`const TSLanguage *`),
+// for use with a parsing backend such as common/treesitter NewLanguage().
+func LanguagePtr() unsafe.Pointer {
+	return unsafe.Pointer(C.tree_sitter_java())
 }

--- a/treesitter/json/BUILD.bazel
+++ b/treesitter/json/BUILD.bazel
@@ -10,5 +10,4 @@ go_library(
     copts = ["-Iexternal/*tree-sitter-json"],
     importpath = "github.com/aspect-build/aspect-gazelle/treesitter/json",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_smacker_go_tree_sitter//:go-tree-sitter"],
 )

--- a/treesitter/json/binding.go
+++ b/treesitter/json/binding.go
@@ -3,12 +3,10 @@ package json
 //#include "tree_sitter/parser.h"
 //TSLanguage *tree_sitter_json();
 import "C"
-import (
-	"unsafe"
+import "unsafe"
 
-	sitter "github.com/smacker/go-tree-sitter"
-)
-
-func NewLanguage() *sitter.Language {
-	return sitter.NewLanguage(unsafe.Pointer(C.tree_sitter_json()))
+// LanguagePtr returns the raw tree-sitter grammar (`const TSLanguage *`),
+// for use with a parsing backend such as common/treesitter NewLanguage().
+func LanguagePtr() unsafe.Pointer {
+	return unsafe.Pointer(C.tree_sitter_json())
 }

--- a/treesitter/kotlin/BUILD.bazel
+++ b/treesitter/kotlin/BUILD.bazel
@@ -10,5 +10,4 @@ go_library(
     copts = ["-Iexternal/*tree-sitter-kotlin"],
     importpath = "github.com/aspect-build/aspect-gazelle/treesitter/kotlin",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_smacker_go_tree_sitter//:go-tree-sitter"],
 )

--- a/treesitter/kotlin/binding.go
+++ b/treesitter/kotlin/binding.go
@@ -19,12 +19,10 @@ package kotlin
 //#include "tree_sitter/parser.h"
 //TSLanguage *tree_sitter_kotlin();
 import "C"
-import (
-	"unsafe"
+import "unsafe"
 
-	sitter "github.com/smacker/go-tree-sitter"
-)
-
-func NewLanguage() *sitter.Language {
-	return sitter.NewLanguage(unsafe.Pointer(C.tree_sitter_kotlin()))
+// LanguagePtr returns the raw tree-sitter grammar (`const TSLanguage *`),
+// for use with a parsing backend such as common/treesitter NewLanguage().
+func LanguagePtr() unsafe.Pointer {
+	return unsafe.Pointer(C.tree_sitter_kotlin())
 }

--- a/treesitter/python/BUILD.bazel
+++ b/treesitter/python/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library")
 go_library(
     name = "python",
     srcs = ["binding.go"],
+    cgo = True,
     importpath = "github.com/aspect-build/aspect-gazelle/treesitter/python",
     visibility = ["//visibility:public"],
     deps = [
@@ -11,7 +12,6 @@ go_library(
         # links com_github_smacker_go_tree_sitter//python, so adding a second
         # copy of the same C sources (parser.c / scanner.c) causes duplicate
         # symbol errors at link time in the runner binary.
-        "@com_github_smacker_go_tree_sitter//:go-tree-sitter",
         "@com_github_smacker_go_tree_sitter//python",
     ],
 )

--- a/treesitter/python/binding.go
+++ b/treesitter/python/binding.go
@@ -1,10 +1,19 @@
 package python
 
+//typedef struct TSLanguage TSLanguage;
+//TSLanguage *tree_sitter_python();
+import "C"
 import (
-	sitter "github.com/smacker/go-tree-sitter"
-	sitter_python "github.com/smacker/go-tree-sitter/python"
+	"unsafe"
+
+	// Linked only for its C grammar symbols (tree_sitter_python). A standalone
+	// @tree-sitter-python archive would duplicate parser.c/scanner.c symbols in
+	// binaries that also link go-tree-sitter's python package (see BUILD note).
+	_ "github.com/smacker/go-tree-sitter/python"
 )
 
-func NewLanguage() *sitter.Language {
-	return sitter_python.GetLanguage()
+// LanguagePtr returns the raw tree-sitter grammar (`const TSLanguage *`),
+// for use with a parsing backend such as common/treesitter NewLanguage().
+func LanguagePtr() unsafe.Pointer {
+	return unsafe.Pointer(C.tree_sitter_python())
 }

--- a/treesitter/ruby/BUILD.bazel
+++ b/treesitter/ruby/BUILD.bazel
@@ -10,5 +10,4 @@ go_library(
     copts = ["-Iexternal/*tree-sitter-ruby"],
     importpath = "github.com/aspect-build/aspect-gazelle/treesitter/ruby",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_smacker_go_tree_sitter//:go-tree-sitter"],
 )

--- a/treesitter/ruby/binding.go
+++ b/treesitter/ruby/binding.go
@@ -3,12 +3,10 @@ package ruby
 //#include "tree_sitter/parser.h"
 //TSLanguage *tree_sitter_ruby();
 import "C"
-import (
-	"unsafe"
+import "unsafe"
 
-	sitter "github.com/smacker/go-tree-sitter"
-)
-
-func NewLanguage() *sitter.Language {
-	return sitter.NewLanguage(unsafe.Pointer(C.tree_sitter_ruby()))
+// LanguagePtr returns the raw tree-sitter grammar (`const TSLanguage *`),
+// for use with a parsing backend such as common/treesitter NewLanguage().
+func LanguagePtr() unsafe.Pointer {
+	return unsafe.Pointer(C.tree_sitter_ruby())
 }

--- a/treesitter/rust/BUILD.bazel
+++ b/treesitter/rust/BUILD.bazel
@@ -10,5 +10,4 @@ go_library(
     copts = ["-Iexternal/*tree-sitter-rust"],
     importpath = "github.com/aspect-build/aspect-gazelle/treesitter/rust",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_smacker_go_tree_sitter//:go-tree-sitter"],
 )

--- a/treesitter/rust/binding.go
+++ b/treesitter/rust/binding.go
@@ -3,12 +3,10 @@ package rust
 //#include "tree_sitter/parser.h"
 //TSLanguage *tree_sitter_rust();
 import "C"
-import (
-	"unsafe"
+import "unsafe"
 
-	sitter "github.com/smacker/go-tree-sitter"
-)
-
-func NewLanguage() *sitter.Language {
-	return sitter.NewLanguage(unsafe.Pointer(C.tree_sitter_rust()))
+// LanguagePtr returns the raw tree-sitter grammar (`const TSLanguage *`),
+// for use with a parsing backend such as common/treesitter NewLanguage().
+func LanguagePtr() unsafe.Pointer {
+	return unsafe.Pointer(C.tree_sitter_rust())
 }

--- a/treesitter/starlark/BUILD.bazel
+++ b/treesitter/starlark/BUILD.bazel
@@ -10,5 +10,4 @@ go_library(
     copts = ["-Iexternal/*tree-sitter-starlark"],
     importpath = "github.com/aspect-build/aspect-gazelle/treesitter/starlark",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_smacker_go_tree_sitter//:go-tree-sitter"],
 )

--- a/treesitter/starlark/binding.go
+++ b/treesitter/starlark/binding.go
@@ -3,12 +3,10 @@ package starlark
 //#include "tree_sitter/parser.h"
 //TSLanguage *tree_sitter_starlark();
 import "C"
-import (
-	"unsafe"
+import "unsafe"
 
-	sitter "github.com/smacker/go-tree-sitter"
-)
-
-func NewLanguage() *sitter.Language {
-	return sitter.NewLanguage(unsafe.Pointer(C.tree_sitter_starlark()))
+// LanguagePtr returns the raw tree-sitter grammar (`const TSLanguage *`),
+// for use with a parsing backend such as common/treesitter NewLanguage().
+func LanguagePtr() unsafe.Pointer {
+	return unsafe.Pointer(C.tree_sitter_starlark())
 }

--- a/treesitter/tsx/BUILD.bazel
+++ b/treesitter/tsx/BUILD.bazel
@@ -10,5 +10,4 @@ go_library(
     copts = ["-Iexternal/*tree-sitter-typescript"],
     importpath = "github.com/aspect-build/aspect-gazelle/treesitter/tsx",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_smacker_go_tree_sitter//:go-tree-sitter"],
 )

--- a/treesitter/tsx/binding.go
+++ b/treesitter/tsx/binding.go
@@ -19,12 +19,10 @@ package tsx
 //#include "tree_sitter/parser.h"
 //TSLanguage *tree_sitter_tsx();
 import "C"
-import (
-	"unsafe"
+import "unsafe"
 
-	sitter "github.com/smacker/go-tree-sitter"
-)
-
-func NewLanguage() *sitter.Language {
-	return sitter.NewLanguage(unsafe.Pointer(C.tree_sitter_tsx()))
+// LanguagePtr returns the raw tree-sitter grammar (`const TSLanguage *`),
+// for use with a parsing backend such as common/treesitter NewLanguage().
+func LanguagePtr() unsafe.Pointer {
+	return unsafe.Pointer(C.tree_sitter_tsx())
 }

--- a/treesitter/typescript/BUILD.bazel
+++ b/treesitter/typescript/BUILD.bazel
@@ -10,5 +10,4 @@ go_library(
     copts = ["-Iexternal/*tree-sitter-typescript"],
     importpath = "github.com/aspect-build/aspect-gazelle/treesitter/typescript",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_smacker_go_tree_sitter//:go-tree-sitter"],
 )

--- a/treesitter/typescript/binding.go
+++ b/treesitter/typescript/binding.go
@@ -19,12 +19,10 @@ package typescript
 //#include "tree_sitter/parser.h"
 //TSLanguage *tree_sitter_typescript();
 import "C"
-import (
-	"unsafe"
+import "unsafe"
 
-	sitter "github.com/smacker/go-tree-sitter"
-)
-
-func NewLanguage() *sitter.Language {
-	return sitter.NewLanguage(unsafe.Pointer(C.tree_sitter_typescript()))
+// LanguagePtr returns the raw tree-sitter grammar (`const TSLanguage *`),
+// for use with a parsing backend such as common/treesitter NewLanguage().
+func LanguagePtr() unsafe.Pointer {
+	return unsafe.Pointer(C.tree_sitter_typescript())
 }


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
