### PR TITLE
refactor: seal the treesitter backend behind Language/TreeQuery interfaces

### DIFF
--- a/common/treesitter/parser.go
+++ b/common/treesitter/parser.go
@@ -58,8 +58,16 @@ const (
 	Python                      = "python"
 )
 
-type Language any
+// Language is an opaque grammar handle, sealed to this package so the
+// parsing backend can change without affecting callers.
+type Language interface {
+	Grammar() LanguageGrammar
 
+	// sitterLang seals the interface to in-package implementations.
+	sitterLang() *sitter.Language
+}
+
+// NewLanguage wraps a raw tree-sitter grammar (`const TSLanguage *`).
 func NewLanguage(grammar LanguageGrammar, langPtr unsafe.Pointer) Language {
 	return &treeLanguage{
 		grammar: grammar,
@@ -70,6 +78,16 @@ func NewLanguage(grammar LanguageGrammar, langPtr unsafe.Pointer) Language {
 type treeLanguage struct {
 	grammar LanguageGrammar
 	lang    *sitter.Language
+}
+
+var _ Language = (*treeLanguage)(nil)
+
+func (tree *treeLanguage) Grammar() LanguageGrammar {
+	return tree.grammar
+}
+
+func (tree *treeLanguage) sitterLang() *sitter.Language {
+	return tree.lang
 }
 
 func (tree *treeLanguage) String() string {
@@ -91,7 +109,7 @@ type AST interface {
 	Close()
 }
 type treeAst struct {
-	lang       *treeLanguage
+	lang       Language
 	filePath   string
 	sourceCode []byte
 
@@ -111,7 +129,7 @@ func (tree *treeAst) Close() {
 }
 
 func (tree *treeAst) String() string {
-	return fmt.Sprintf("treeAst{\n lang: %q,\n filePath: %q,\n AST:\n  %v\n}", tree.lang.grammar, tree.filePath, tree.sitterTree.RootNode().String())
+	return fmt.Sprintf("treeAst{\n lang: %q,\n filePath: %q,\n AST:\n  %v\n}", tree.lang.Grammar(), tree.filePath, tree.sitterTree.RootNode().String())
 }
 
 func PathToLanguage(p string) LanguageGrammar {
@@ -185,12 +203,12 @@ func ParseSourceCode(lang Language, filePath string, sourceCode []byte) (AST, er
 
 	parser := sitter.NewParser()
 	defer parser.Close()
-	parser.SetLanguage(lang.(*treeLanguage).lang)
+	parser.SetLanguage(lang.sitterLang())
 
 	tree, err := parser.ParseCtx(ctx, nil, sourceCode)
 	if err != nil {
 		return nil, err
 	}
 
-	return &treeAst{lang: lang.(*treeLanguage), filePath: filePath, sourceCode: sourceCode, sitterTree: tree}, nil
+	return &treeAst{lang: lang, filePath: filePath, sourceCode: sourceCode, sitterTree: tree}, nil
 }

--- a/common/treesitter/queries.go
+++ b/common/treesitter/queries.go
@@ -1,6 +1,7 @@
 package treesitter
 
 import (
+	"bytes"
 	"fmt"
 	"iter"
 	"strings"
@@ -13,20 +14,20 @@ import (
 
 var ErrorsQuery = `(ERROR) @error`
 
-type TreeQuery any
+// TreeQuery is an opaque compiled query from GetQuery, sealed to this package.
+type TreeQuery interface {
+	sealedQuery()
+}
 
 // A cache of parsed queries per language
 var queryCache = sync.Map{}
 
-func GetQuery(lang Language, queryStr string) (*sitterQuery, error) {
-	grammar := lang.(*treeLanguage).grammar
-	treeLang := lang.(*treeLanguage).lang
-
-	key := string(grammar) + ":" + queryStr
+func GetQuery(lang Language, queryStr string) (TreeQuery, error) {
+	key := string(lang.Grammar()) + ":" + queryStr
 
 	q, found := queryCache.Load(key)
 	if !found {
-		sq, err := newSitterQuery(treeLang, queryStr)
+		sq, err := newSitterQuery(lang.sitterLang(), queryStr)
 		if err != nil {
 			return nil, err
 		}
@@ -37,6 +38,7 @@ func GetQuery(lang Language, queryStr string) (*sitterQuery, error) {
 
 func (tree *treeAst) Query(query TreeQuery) iter.Seq[ASTQueryResult] {
 	return func(yield func(ASTQueryResult) bool) {
+		// TreeQuery is sealed; *sitterQuery is the only implementation.
 		q := query.(*sitterQuery)
 
 		// Execute the query.
@@ -85,13 +87,12 @@ func (tree *treeAst) QueryErrors() []error {
 	if err != nil {
 		BazelLog.Fatalf("Failed to create util 'ErrorsQuery': %v", err)
 	}
+	q := query.(*sitterQuery)
 
-	// Execute the import query
 	qc := sitter.NewQueryCursor()
 	defer qc.Close()
-	qc.Exec(query.q, node)
+	qc.Exec(q.q, node)
 
-	// Collect import statements from the query results
 	for {
 		m, ok := qc.NextMatch()
 		if !ok {
@@ -99,34 +100,31 @@ func (tree *treeAst) QueryErrors() []error {
 		}
 
 		// Apply predicates to filter results.
-		if !matchesAllPredicates(query, m, qc, tree.sourceCode) {
+		if !matchesAllPredicates(q, m, qc, tree.sourceCode) {
 			continue
 		}
 
 		for _, c := range m.Captures {
-			at := c.Node
-			atStart := at.StartPoint()
-			show := c.Node
-
-			// Navigate up the AST to include the full source line
-			if atStart.Column > 0 {
-				for show.StartPoint().Row > 0 && show.StartPoint().Row == atStart.Row && show.Parent() != nil {
-					show = show.Parent()
-				}
-			}
-
-			// Extract only that line from the parent Node
-			lineI := int(atStart.Row - show.StartPoint().Row)
-			colI := int(atStart.Column)
-			line := strings.Split(show.Content(tree.sourceCode), "\n")[lineI]
-
-			pre := fmt.Sprintf("     %d: ", atStart.Row+1)
-			msg := pre + line
-			arw := strings.Repeat(" ", len(pre)+colI) + "^"
-
-			errors = append(errors, fmt.Errorf("%s\n%s", msg, arw))
+			at := c.Node.StartPoint()
+			errors = append(errors, queryErrorAt(tree.sourceCode, at.Row, at.Column, c.Node.StartByte()))
 		}
 	}
 
 	return errors
+}
+
+// queryErrorAt renders the error's source line with a caret at the error
+// position, from plain position data — no AST navigation.
+func queryErrorAt(source []byte, row, col, startByte uint32) error {
+	// col is the byte offset within the line.
+	lineStart := int(startByte - col)
+	lineEnd := len(source)
+	if i := bytes.IndexByte(source[startByte:], '\n'); i >= 0 {
+		lineEnd = int(startByte) + i
+	}
+
+	pre := fmt.Sprintf("     %d: ", row+1)
+	arw := strings.Repeat(" ", len(pre)+int(col)) + "^"
+
+	return fmt.Errorf("%s%s\n%s", pre, source[lineStart:lineEnd], arw)
 }

--- a/common/treesitter/query.go
+++ b/common/treesitter/query.go
@@ -23,6 +23,8 @@ type sitterQuery struct {
 
 var _ TreeQuery = (*sitterQuery)(nil)
 
+func (q *sitterQuery) sealedQuery() {}
+
 func newSitterQuery(lang *sitter.Language, query string) (*sitterQuery, error) {
 	q, err := sitter.NewQuery([]byte(query), lang)
 	if err != nil {


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
