### PR TITLE
fix: handle bytes and int64 overflow in starlark value reads

### DIFF
--- a/language/orion/starlark/utils/util.go
+++ b/language/orion/starlark/utils/util.go
@@ -29,6 +29,8 @@ func Write(v any) starlark.Value {
 		return starlark.MakeInt64(v)
 	case float64:
 		return starlark.Float(v)
+	case []byte:
+		return starlark.Bytes(v)
 	case []string:
 		return WriteList(v, WriteString)
 	case []any:
@@ -128,10 +130,17 @@ func ReadRecurse(v starlark.Value, read func(v starlark.Value) (any, error)) (an
 	case starlark.String:
 		return v.GoString(), nil
 	case starlark.Int:
-		i, _ := v.Int64()
+		i, ok := v.Int64()
+		if !ok {
+			return nil, fmt.Errorf("integer %v does not fit in int64", v)
+		}
 		return i, nil
 	case starlark.Float:
 		return float64(v), nil
+	// Bytes must be matched before the Indexable case: Bytes.Index returns
+	// another Bytes, which would recurse without terminating.
+	case starlark.Bytes:
+		return []byte(v), nil
 	case *starlark.List:
 		return ReadList(v, read)
 	case *starlark.Dict:

--- a/language/orion/starlark/utils/util_test.go
+++ b/language/orion/starlark/utils/util_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 
@@ -110,6 +111,36 @@ func TestReadWrite(t *testing.T) {
 		}
 		if v != 123.45 {
 			t.Errorf("Expected 123.45")
+		}
+	})
+
+	t.Run("[]byte <=> Bytes", func(t *testing.T) {
+		if Write([]byte("hello")) != starlark.Bytes("hello") {
+			t.Errorf("Expected hello")
+		}
+
+		// Bytes must not fall through to the Indexable case: Bytes.Index
+		// returns another Bytes, so that path would never terminate.
+		v, err := Read(starlark.Bytes("hello"))
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		b, isBytes := v.([]byte)
+		if !isBytes {
+			t.Fatalf("Expected []byte, got %T", v)
+		}
+		if string(b) != "hello" {
+			t.Errorf("Expected hello, got %q", b)
+		}
+	})
+
+	t.Run("Int overflowing int64 => error", func(t *testing.T) {
+		_, err := Read(starlark.MakeUint64(math.MaxUint64))
+		if err == nil {
+			t.Fatal("Expected an error")
+		}
+		if !strings.Contains(err.Error(), "does not fit in int64") {
+			t.Errorf("Expected overflow error, got %v", err)
 		}
 	})
 


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
