### PR TITLE
fix: derive context AttrNames from the embedded PrepareContext

### DIFF
--- a/language/orion/plugin/plugin.star.go
+++ b/language/orion/plugin/plugin.star.go
@@ -123,7 +123,7 @@ func (ctx DeclareTargetsContext) String() string {
 	return fmt.Sprintf("DeclareTargetsContext{PrepareContext: %v, sources: %v, targets: %v}", ctx.PrepareContext, ctx.Sources, ctx.Targets)
 }
 func (ctx DeclareTargetsContext) AttrNames() []string {
-	return []string{"repo_name", "rel", "properties", "sources", "targets"}
+	return append(ctx.PrepareContext.AttrNames(), "sources", "targets", "add_symbol")
 }
 func (ctx DeclareTargetsContext) Type() string { return "DeclareTargetsContext" }
 
@@ -504,7 +504,7 @@ func (a AnalyzeContext) Attr(name string) (starlark.Value, error) {
 }
 
 func (a AnalyzeContext) AttrNames() []string {
-	return []string{"repo_name", "rel", "properties", "source", "add_symbol"}
+	return append(a.PrepareContext.AttrNames(), "source", "add_symbol")
 }
 func (a AnalyzeContext) Freeze() {}
 func (a AnalyzeContext) Hash() (uint32, error) {

--- a/language/orion/tests/starzelle/context-attrs/BUILD.out
+++ b/language/orion/tests/starzelle/context-attrs/BUILD.out
@@ -1,0 +1,14 @@
+load("@ctx-test//:rules.bzl", "ctx_attrs")
+
+ctx_attrs(
+    name = "ctx",
+    analyze_ctx_attrs = "//:analyze_ctx",
+    declare_ctx_attrs = [
+        "add_symbol",
+        "properties",
+        "rel",
+        "repo_name",
+        "sources",
+        "targets",
+    ],
+)

--- a/language/orion/tests/starzelle/context-attrs/WORKSPACE
+++ b/language/orion/tests/starzelle/context-attrs/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "context-attrs")

--- a/language/orion/tests/starzelle/context-attrs/a.txt
+++ b/language/orion/tests/starzelle/context-attrs/a.txt
@@ -1,0 +1,1 @@
+content

--- a/language/orion/tests/starzelle/context-attrs/context-attrs.axl
+++ b/language/orion/tests/starzelle/context-attrs/context-attrs.axl
@@ -1,0 +1,43 @@
+# dir(ctx) is built from each context's AttrNames, pinning the
+# starlark-visible attribute surface. A name missing there is invisible to
+# dir() and typo suggestions even when the attribute itself works - e.g.
+# add_symbol was once absent from the DeclareTargetsContext listing.
+aspect.gazelle_rule_kind("ctx_attrs", {
+    "From": "@ctx-test//:rules.bzl",
+    "ResolveAttrs": ["analyze_ctx_attrs"],
+})
+
+def prepare(_):
+    return aspect.PrepareResult(
+        sources = [aspect.SourceExtensions(".txt")],
+    )
+
+def analyze(ctx):
+    # Surface dir(ctx) of the AnalyzeContext through the symbol database: the
+    # declare import below only resolves if this id matches exactly.
+    ctx.add_symbol(
+        id = " ".join(dir(ctx)),
+        provider_type = "ctx-attrs",
+        label = aspect.Label(name = "analyze_ctx"),
+    )
+
+def declare(ctx):
+    ctx.targets.add(
+        name = "ctx",
+        kind = "ctx_attrs",
+        attrs = {
+            "declare_ctx_attrs": dir(ctx),
+            "analyze_ctx_attrs": aspect.Import(
+                id = "add_symbol properties rel repo_name source",
+                provider = "ctx-attrs",
+                optional = True,
+            ),
+        },
+    )
+
+aspect.orion_extension(
+    id = "context-attrs-test",
+    prepare = prepare,
+    analyze = analyze,
+    declare = declare,
+)


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
