### PR TITLE
feat(kotlin): introduce custom directives and configuration

### DIFF
--- a/language/kotlin/README.md
+++ b/language/kotlin/README.md
@@ -16,7 +16,7 @@ This extension supports several custom directives in your `BUILD.bazel` files to
 
 > [!WARNING]
 > **Implementation Status**: These directives are currently defined, parsed, and validated into configuration structures within this branch, but **they are not yet wired up to target generation or import resolution in this repository**. 
-> - The parser infrastructure to extract the necessary top-level symbols and star imports is implemented in [PR #2](https://github.com/gonzojive/aspect-gazelle/pull/2).
+> - The parser infrastructure to extract the necessary top-level symbols and star imports is implemented in [PR #410](https://github.com/aspect-build/aspect-gazelle/pull/410).
 > - The full wiring/implementation of resolution logic utilizing these directives is forthcoming in subsequent PRs (or downstream forks like `gazelle-kotlin`).
 > - *TODO: Remove this warning when full resolution/generation support is wired up locally in this extension.*
 
@@ -24,18 +24,19 @@ This extension supports several custom directives in your `BUILD.bazel` files to
 * **Default**: `enabled`
 * Controls whether the Kotlin Gazelle extension processes files and generates targets in the current package and its subdirectories.
 
-### `# gazelle:kotlin_only_use_existing_library_targets [true|false]`
-* **Default**: `false`
+### `# gazelle:kotlin_generate_mode [package|file|existing]`
+* **Default**: `package`
 * **Behavior**:
-  - `false`: Gazelle runs in automatic target-generation mode. It will automatically construct and insert a `kt_jvm_library` target for directories containing Kotlin source files if they do not already exist.
-  - `true`: Gazelle operates in strict update-only mode. It will never generate new `kt_jvm_library` targets. Instead, it expects developers to manually define targets and will only update dependencies for existing library rules. If any Kotlin source files are not listed in the `srcs` of an existing target, Gazelle will raise an error.
+  - `package`: Gazelle runs in automatic target-generation mode. It will automatically construct and insert a `kt_jvm_library` target for directories containing Kotlin source files if they do not already exist.
+  - `file`: Auto-generate one library target per Kotlin source file (not yet implemented).
+  - `existing`: Gazelle operates in strict mode. It will never generate new `kt_jvm_library` targets. Instead, it expects developers to manually define targets and will only update dependencies for existing library rules. If any Kotlin source files are not listed in the `srcs` of an existing target, Gazelle will raise an error. To skip files, exclude them using `# gazelle:exclude` or `.gitignore`.
 
 ### `# gazelle:kotlin_library_suffix [suffix]`
 * **Default**: `_lib`
 * Configures the target name suffix used for auto-generated `kt_jvm_library` targets. For example, a package directory named `hello` will result in a target named `hello_lib` by default.
 
-### `# gazelle:kotlin_export_granularity [package|top_level_objects]`
-* **Default**: `package`
+### `# gazelle:kotlin_resolve_granularity [package|symbol]`
+* **Default**: `package` (to be updated to `symbol`)
 * **Behavior**:
   - `package`: Maps and resolves dependencies based on the package statements of source files.
-  - `top_level_objects`: Maps and resolves dependencies based on the exact top-level declarations (classes, interfaces, singleton objects, functions, properties, and typealiases) declared within files. This provides precise, declaration-level resolution and is helpful for fine-grained dependency tracking when multiple targets share a package name.
+  - `symbol`: Maps and resolves dependencies based on the exact top-level declarations (classes, interfaces, singleton objects, functions, properties, and typealiases) declared within files. This provides precise, declaration-level resolution and is helpful for fine-grained dependency tracking when multiple targets share a package name.

--- a/language/kotlin/README.md
+++ b/language/kotlin/README.md
@@ -9,3 +9,27 @@ This was originally implemented by @jbedard in https://github.com/aspect-build/a
 and has been separated out to a standalone git repository and Bazel module.
 
 The work was sponsored by @reddaly and the GoogleX Tapestry team, thanks so much!
+
+## Configuration Directives
+
+This extension supports several custom directives in your `BUILD.bazel` files to control target generation, target naming, and import resolution behavior:
+
+### `# gazelle:kotlin [enabled|disabled]`
+* **Default**: `enabled`
+* Controls whether the Kotlin Gazelle extension processes files and generates targets in the current package and its subdirectories.
+
+### `# gazelle:kotlin_only_use_existing_library_targets [true|false]`
+* **Default**: `false`
+* **Behavior**:
+  - `false`: Gazelle runs in automatic target-generation mode. It will automatically construct and insert a `kt_jvm_library` target for directories containing Kotlin source files if they do not already exist.
+  - `true`: Gazelle operates in strict update-only mode. It will never generate new `kt_jvm_library` targets. Instead, it expects developers to manually define targets and will only update dependencies for existing library rules. If any Kotlin source files are not listed in the `srcs` of an existing target, Gazelle will raise an error.
+
+### `# gazelle:kotlin_library_suffix [suffix]`
+* **Default**: `_lib`
+* Configures the target name suffix used for auto-generated `kt_jvm_library` targets. For example, a package directory named `hello` will result in a target named `hello_lib` by default.
+
+### `# gazelle:kotlin_export_granularity [package|top_level_objects]`
+* **Default**: `package`
+* **Behavior**:
+  - `package`: Maps and resolves dependencies based on the package statements of source files.
+  - `top_level_objects`: Maps and resolves dependencies based on the exact top-level objects (classes, interfaces, functions, objects) declared within files. This provides class-level resolution and is helpful for fine-grained dependency tracking.

--- a/language/kotlin/README.md
+++ b/language/kotlin/README.md
@@ -32,4 +32,4 @@ This extension supports several custom directives in your `BUILD.bazel` files to
 * **Default**: `package`
 * **Behavior**:
   - `package`: Maps and resolves dependencies based on the package statements of source files.
-  - `top_level_objects`: Maps and resolves dependencies based on the exact top-level objects (classes, interfaces, functions, objects) declared within files. This provides class-level resolution and is helpful for fine-grained dependency tracking.
+  - `top_level_objects`: Maps and resolves dependencies based on the exact top-level declarations (classes, interfaces, singleton objects, functions, properties, and typealiases) declared within files. This provides precise, declaration-level resolution and is helpful for fine-grained dependency tracking when multiple targets share a package name.

--- a/language/kotlin/README.md
+++ b/language/kotlin/README.md
@@ -12,7 +12,13 @@ The work was sponsored by @reddaly and the GoogleX Tapestry team, thanks so much
 
 ## Configuration Directives
 
-This extension supports several custom directives in your `BUILD.bazel` files to control target generation, target naming, and import resolution behavior:
+This extension supports several custom directives in your `BUILD.bazel` files to control target generation, target naming, and import resolution behavior.
+
+> [!WARNING]
+> **Implementation Status**: These directives are currently defined, parsed, and validated into configuration structures within this branch, but **they are not yet wired up to target generation or import resolution in this repository**. 
+> - The parser infrastructure to extract the necessary top-level symbols and star imports is implemented in [PR #2](https://github.com/gonzojive/aspect-gazelle/pull/2).
+> - The full wiring/implementation of resolution logic utilizing these directives is forthcoming in subsequent PRs (or downstream forks like `gazelle-kotlin`).
+> - *TODO: Remove this warning when full resolution/generation support is wired up locally in this extension.*
 
 ### `# gazelle:kotlin [enabled|disabled]`
 * **Default**: `enabled`

--- a/language/kotlin/configure.go
+++ b/language/kotlin/configure.go
@@ -3,7 +3,6 @@ package gazelle
 import (
 	"flag"
 
-	common "github.com/aspect-build/aspect-gazelle/common"
 	BazelLog "github.com/aspect-build/aspect-gazelle/common/logger"
 	"github.com/aspect-build/aspect-gazelle/language/kotlin/kotlinconfig"
 	jvm_javaconfig "github.com/bazel-contrib/rules_jvm/java/gazelle/javaconfig"
@@ -15,11 +14,23 @@ import (
 
 var _ config.Configurer = (*kotlinLang)(nil)
 
+var directivesByKey map[string]kotlinconfig.GenericDirective
+
+func init() {
+	directivesByKey = make(map[string]kotlinconfig.GenericDirective)
+	for _, dir := range kotlinconfig.AllDirectives() {
+		directivesByKey[dir.ConfigKey()] = dir
+	}
+}
+
 func (kt *kotlinLang) KnownDirectives() []string {
-	return []string{
-		kotlinconfig.Directive_KotlinExtension,
+	out := []string{
 		jvm_javaconfig.JavaMavenInstallFile,
 	}
+	for _, dir := range kotlinconfig.AllDirectives() {
+		out = append(out, dir.ConfigKey())
+	}
+	return out
 }
 
 func (kc *kotlinLang) initRootConfig(c *config.Config) kotlinconfig.Configs {
@@ -48,13 +59,19 @@ func (kt *kotlinLang) Configure(c *config.Config, rel string, f *rule.File) {
 			switch d.Key {
 
 			case kotlinconfig.Directive_KotlinExtension:
-				cfg.SetGenerationEnabled(common.ReadEnabled(d))
-
-			// TODO: invoke java gazelle.Configure() to support all jvm directives?
-			// TODO: JavaMavenRepositoryName: https://github.com/bazel-contrib/rules_jvm/commit/e46bb11bedb2ead45309eae04619caca684f6243
+				if err := kotlinconfig.EnabledDirective.Parse(d, cfg); err != nil {
+					BazelLog.Fatalf("failed to parse directive %v: %v", d, err)
+				}
 
 			case jvm_javaconfig.JavaMavenInstallFile:
 				cfg.SetMavenInstallFile(d.Value)
+
+			default:
+				if dir, ok := directivesByKey[d.Key]; ok {
+					if err := dir.Parse(d, cfg); err != nil {
+						BazelLog.Fatalf("error parsing kotlin directive: %v", err)
+					}
+				}
 			}
 		}
 	}

--- a/language/kotlin/kotlinconfig/BUILD.bazel
+++ b/language/kotlin/kotlinconfig/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["config.go"],
     importpath = "github.com/aspect-build/aspect-gazelle/language/kotlin/kotlinconfig",
     visibility = ["//visibility:public"],
-    deps = ["@contrib_rules_jvm//java/gazelle/javaconfig"],
+    deps = [
+        "@contrib_rules_jvm//java/gazelle/javaconfig",
+        "@gazelle//rule",
+    ],
 )

--- a/language/kotlin/kotlinconfig/BUILD.bazel
+++ b/language/kotlin/kotlinconfig/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "kotlinconfig",
@@ -7,6 +7,15 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@contrib_rules_jvm//java/gazelle/javaconfig",
+        "@gazelle//rule",
+    ],
+)
+
+go_test(
+    name = "kotlinconfig_test",
+    srcs = ["config_test.go"],
+    deps = [
+        ":kotlinconfig",
         "@gazelle//rule",
     ],
 )

--- a/language/kotlin/kotlinconfig/config.go
+++ b/language/kotlin/kotlinconfig/config.go
@@ -64,12 +64,23 @@ var (
 		func(val bool, cfg *KotlinConfig) { cfg.SetGenerationEnabled(val) },
 	}
 
-	// A directive taking a single enabled/disabled argument that configures whether the
-	// plugin should generate new library sources.
-	OnlyUseExistingLibraryTargetsDirective = &Directive[bool]{
-		"kotlin_only_use_existing_library_targets",
-		parseEnabledDisableDirective,
-		func(val bool, cfg *KotlinConfig) { cfg.SetOnlyUseExistingLibraryTargets(val) },
+	// GenerateModeDirective configures the target generation style.
+	//
+	// Valid values:
+	//
+	// - "package": Default. Gazelle runs in automatic target-generation mode, constructing
+	// and inserting a kt_jvm_library target for directories containing Kotlin source files.
+	//
+	// - "file": Auto-generate one target per Kotlin source file (not yet implemented).
+	//
+	// - "existing": Gazelle operates in strict mode. It updates existing library targets but
+	// refuses to create new ones. If a Kotlin file is not mapped to any existing library
+	// target's srcs, Gazelle fails with an error. To skip files, exclude them using
+	// '# gazelle:exclude' or .gitignore.
+	GenerateModeDirective = &Directive[GenerateMode]{
+		"kotlin_generate_mode",
+		parseGenerateMode,
+		func(val GenerateMode, cfg *KotlinConfig) { cfg.SetGenerateMode(val) },
 	}
 
 	// A directive that configures the suffix used to name kt_jvm_library rules generated
@@ -86,25 +97,22 @@ var (
 		func(val string, cfg *KotlinConfig) { cfg.SetLibrarySuffix(val) },
 	}
 
-	// A directive that configures how the set of Kotlin identifiers associated
+	// ResolveGranularityDirective configures how the set of Kotlin identifiers associated
 	// with a source file should be determined.
 	//
 	// Valid values:
 	//
-	// - "package": Default, specifies that the package statement of the source
-	// file will be used to determine the set of Kotlin identifiers associated
+	// - "package": Default (to be updated to symbol). Specifies that the package statement
+	// of the source file will be used to determine the set of Kotlin identifiers associated
 	// with a source file (and that source files' Bazel target).
 	//
-	// - "top_level_objects": Specifies that the top-level objects defined in
-	// the source files of the target will be used to determine the identifiers
-	// associated with the target. For example, if a class Foo is defined
-	// in a source file with package com.example, the "com.example.Foo"
-	// identifier prefix would be associated with the library target of the
-	// source file and used to resolve imports.
-	ExportGranularityDirective = &Directive[ExportGranularity]{
-		"kotlin_export_granularity",
-		parseExportGranularity,
-		func(val ExportGranularity, cfg *KotlinConfig) { cfg.SetExportGranularity(val) },
+	// - "symbol": Specifies that the top-level declarations (classes, interfaces,
+	// singleton objects, functions, properties, and typealiases) defined in the source
+	// files of the target will be used to determine the identifiers associated with the target.
+	ResolveGranularityDirective = &Directive[ResolveGranularity]{
+		"kotlin_resolve_granularity",
+		parseResolveGranularity,
+		func(val ResolveGranularity, cfg *KotlinConfig) { cfg.SetResolveGranularity(val) },
 	}
 )
 
@@ -114,9 +122,9 @@ var (
 func AllDirectives() []GenericDirective {
 	return []GenericDirective{
 		EnabledDirective,
-		OnlyUseExistingLibraryTargetsDirective,
+		GenerateModeDirective,
 		LibraryRuleNameSuffix,
-		ExportGranularityDirective,
+		ResolveGranularityDirective,
 	}
 }
 
@@ -131,22 +139,38 @@ func parseEnabledDisableDirective(d rule.Directive) (bool, error) {
 	}
 }
 
-// ExportGranularity defines valid values for the [ExportGranularityDirective].
-type ExportGranularity string
+// GenerateMode defines valid values for the [GenerateModeDirective].
+type GenerateMode string
 
 const (
-	// Package-level identifier resolution. See [ExportGranularityPackage]
-	ExportGranularityPackage = "package"
-	// Identifier resolution.
-	ExportGranularityTopLevelObjects = "top_level_objects"
+	GenerateModePackage  GenerateMode = "package"
+	GenerateModeFile     GenerateMode = "file"
+	GenerateModeExisting GenerateMode = "existing"
 )
 
-func parseExportGranularity(d rule.Directive) (ExportGranularity, error) {
-	switch value := ExportGranularity(strings.TrimSpace(d.Value)); value {
-	case ExportGranularityPackage, ExportGranularityTopLevelObjects:
+func parseGenerateMode(d rule.Directive) (GenerateMode, error) {
+	switch value := GenerateMode(strings.TrimSpace(d.Value)); value {
+	case GenerateModePackage, GenerateModeFile, GenerateModeExisting:
 		return value, nil
 	default:
-		return "", fmt.Errorf("invalid directive value %q for key %q: expected one of {%s, %s}", d.Key, d.Value, ExportGranularityPackage, ExportGranularityTopLevelObjects)
+		return "", fmt.Errorf("invalid directive value %q for key %q: expected one of {%s, %s, %s}", d.Value, d.Key, GenerateModePackage, GenerateModeFile, GenerateModeExisting)
+	}
+}
+
+// ResolveGranularity defines valid values for the [ResolveGranularityDirective].
+type ResolveGranularity string
+
+const (
+	ResolveGranularityPackage ResolveGranularity = "package"
+	ResolveGranularitySymbol  ResolveGranularity = "symbol"
+)
+
+func parseResolveGranularity(d rule.Directive) (ResolveGranularity, error) {
+	switch value := ResolveGranularity(strings.TrimSpace(d.Value)); value {
+	case ResolveGranularityPackage, ResolveGranularitySymbol:
+		return value, nil
+	default:
+		return "", fmt.Errorf("invalid directive value %q for key %q: expected one of {%s, %s}", d.Value, d.Key, ResolveGranularityPackage, ResolveGranularitySymbol)
 	}
 }
 
@@ -175,26 +199,25 @@ type KotlinConfig struct {
 	// for the current package.
 	generationEnabled bool
 
-	// onlyUseExistingLibraryTargets, when true, disables automatic creation of
-	// new `kt_jvm_library` rules, restricting Gazelle to only update the dependency
-	// attributes of existing library targets.
-	onlyUseExistingLibraryTargets bool
+	// generateMode defines the style of target generation.
+	generateMode GenerateMode
 
-	// exportGranularity defines whether targets publish/resolve imports at
-	// the package prefix level or at the individual top-level class/object level.
-	exportGranularity ExportGranularity
+	// resolveGranularity defines whether targets publish/resolve imports at
+	// the package prefix level or at the individual top-level symbol level.
+	resolveGranularity ResolveGranularity
 }
 
 type Configs = map[string]*KotlinConfig
 
 func New(repoRoot string) *KotlinConfig {
 	return &KotlinConfig{
-		Config:            javaconfig.New(repoRoot),
-		generationEnabled: true,
-		parent:            nil,
-		testFileSuffixes:  []string{"Test.kt"},
-		librarySuffix:     "_lib",
-		exportGranularity: ExportGranularityPackage,
+		Config:             javaconfig.New(repoRoot),
+		generationEnabled:  true,
+		parent:             nil,
+		testFileSuffixes:   []string{"Test.kt"},
+		librarySuffix:      "_lib",
+		generateMode:       GenerateModePackage,
+		resolveGranularity: ResolveGranularityPackage,
 	}
 }
 
@@ -221,14 +244,14 @@ func (c *KotlinConfig) NewChild(childPath string) *KotlinConfig {
 	return &cCopy
 }
 
-// SetExportGranularity sets the export granularity for the config.
-func (c *KotlinConfig) SetExportGranularity(granularity ExportGranularity) {
-	c.exportGranularity = granularity
+// SetResolveGranularity sets the resolve granularity for the config.
+func (c *KotlinConfig) SetResolveGranularity(granularity ResolveGranularity) {
+	c.resolveGranularity = granularity
 }
 
-// ExportGranularity returns the export granularity for the config.
-func (c *KotlinConfig) ExportGranularity() ExportGranularity {
-	return c.exportGranularity
+// ResolveGranularity returns the resolve granularity for the config.
+func (c *KotlinConfig) ResolveGranularity() ResolveGranularity {
+	return c.resolveGranularity
 }
 
 // SetGenerationEnabled sets whether the extension is enabled or not.
@@ -241,16 +264,14 @@ func (c *KotlinConfig) GenerationEnabled() bool {
 	return c.generationEnabled
 }
 
-// SetOnlyUseExistingLibraryTargets sets the value of the
-// only-use-existing-library-targets configuration value.
-func (c *KotlinConfig) SetOnlyUseExistingLibraryTargets(enabled bool) {
-	c.onlyUseExistingLibraryTargets = enabled
+// SetGenerateMode sets the generate mode for the config.
+func (c *KotlinConfig) SetGenerateMode(mode GenerateMode) {
+	c.generateMode = mode
 }
 
-// OnlyUseExistingLibraryTargets returns the value of the
-// only-use-existing-library-targets configuration value.
-func (c *KotlinConfig) OnlyUseExistingLibraryTargets() bool {
-	return c.onlyUseExistingLibraryTargets
+// GenerateMode returns the generate mode for the config.
+func (c *KotlinConfig) GenerateMode() GenerateMode {
+	return c.generateMode
 }
 
 // SetLibrarySuffix sets the suffix to be appended to the names of kt_jvm_library

--- a/language/kotlin/kotlinconfig/config.go
+++ b/language/kotlin/kotlinconfig/config.go
@@ -156,15 +156,32 @@ func parseExportGranularity(d rule.Directive) (ExportGranularity, error) {
 type KotlinConfig struct {
 	*javaconfig.Config
 
+	// parent is the configuration of the parent package directory,
+	// used to inherit configuration settings down the directory hierarchy.
 	parent *KotlinConfig
-	rel    string
 
-	librarySuffix    string
+	// rel is the package path relative to the repository root.
+	rel string
+
+	// librarySuffix is the suffix appended to the folder name to produce
+	// target names for auto-generated `kt_jvm_library` rules (e.g. "_lib").
+	librarySuffix string
+
+	// testFileSuffixes defines the set of file name suffixes (e.g. "Test.kt")
+	// that classify a source file as a test file.
 	testFileSuffixes []string
 
-	generationEnabled             bool
+	// generationEnabled indicates whether Gazelle target generation is active
+	// for the current package.
+	generationEnabled bool
+
+	// onlyUseExistingLibraryTargets, when true, disables automatic creation of
+	// new `kt_jvm_library` rules, restricting Gazelle to only update the dependency
+	// attributes of existing library targets.
 	onlyUseExistingLibraryTargets bool
 
+	// exportGranularity defines whether targets publish/resolve imports at
+	// the package prefix level or at the individual top-level class/object level.
 	exportGranularity ExportGranularity
 }
 

--- a/language/kotlin/kotlinconfig/config.go
+++ b/language/kotlin/kotlinconfig/config.go
@@ -1,17 +1,165 @@
 package kotlinconfig
 
 import (
+	"fmt"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/bazel-contrib/rules_jvm/java/gazelle/javaconfig"
+	"github.com/bazelbuild/bazel-gazelle/rule"
 )
 
 const Directive_KotlinExtension = "kotlin"
 
+// GenericDirective is a version of [Directive] without type arguments.
+type GenericDirective interface {
+	// ConfigKey returns the string key used for this configuration directive
+	// in gazelle comments.
+	//
+	// For a directive like "# gazelle:blah foo bar", returns "blah".
+	ConfigKey() string
+
+	// Parse parses the directive value and updates the config.
+	Parse(dir rule.Directive, cfg *KotlinConfig) error
+}
+
+type Directive[ParsedType any] struct {
+	configKey string
+	parseFn   func(d rule.Directive) (ParsedType, error)
+	setFn     func(val ParsedType, cfg *KotlinConfig)
+}
+
+// ConfigKey returns the string key used for this configuration directive
+// in gazelle comments.
+//
+// For a directive like "# gazelle:blah foo bar", returns "blah".
+func (d *Directive[ParsedType]) ConfigKey() string { return d.configKey }
+
+// parse parses the directive value.
+func (d *Directive[ParsedType]) parse(dir rule.Directive) (ParsedType, error) {
+	return d.parseFn(dir)
+}
+
+// Parse parses the directive value and updates the config.
+func (d *Directive[ParsedType]) Parse(dir rule.Directive, cfg *KotlinConfig) error {
+	val, err := d.parse(dir)
+	if err != nil {
+		return err
+	}
+	d.setFn(val, cfg)
+	return nil
+}
+
+var librarySuffixRegexp = regexp.MustCompile(`^[^\s]*$`)
+
+var (
+	// The directive for enable or disabling the gazelle plugin.
+	EnabledDirective = &Directive[bool]{
+		Directive_KotlinExtension,
+		parseEnabledDisableDirective,
+		func(val bool, cfg *KotlinConfig) { cfg.SetGenerationEnabled(val) },
+	}
+
+	// A directive taking a single enabled/disabled argument that configures whether the
+	// plugin should generate new library sources.
+	OnlyUseExistingLibraryTargetsDirective = &Directive[bool]{
+		"kotlin_only_use_existing_library_targets",
+		parseEnabledDisableDirective,
+		func(val bool, cfg *KotlinConfig) { cfg.SetOnlyUseExistingLibraryTargets(val) },
+	}
+
+	// A directive that configures the suffix used to name kt_jvm_library rules generated
+	// by the plugin.
+	LibraryRuleNameSuffix = &Directive[string]{
+		"kotlin_library_suffix",
+		func(d rule.Directive) (string, error) {
+			value := strings.TrimSpace(d.Value)
+			if !librarySuffixRegexp.MatchString(value) {
+				return "", fmt.Errorf("invalid starlark name part %q - doesn't match regex %s", value, librarySuffixRegexp)
+			}
+			return value, nil
+		},
+		func(val string, cfg *KotlinConfig) { cfg.SetLibrarySuffix(val) },
+	}
+
+	// A directive that configures how the set of Kotlin identifiers associated
+	// with a source file should be determined.
+	//
+	// Valid values:
+	//
+	// - "package": Default, specifies that the package statement of the source
+	// file will be used to determine the set of Kotlin identifiers associated
+	// with a source file (and that source files' Bazel target).
+	//
+	// - "top_level_objects": Specifies that the top-level objects defined in
+	// the source files of the target will be used to determine the identifiers
+	// associated with the target. For example, if a class Foo is defined
+	// in a source file with package com.example, the "com.example.Foo"
+	// identifier prefix would be associated with the library target of the
+	// source file and used to resolve imports.
+	ExportGranularityDirective = &Directive[ExportGranularity]{
+		"kotlin_export_granularity",
+		parseExportGranularity,
+		func(val ExportGranularity, cfg *KotlinConfig) { cfg.SetExportGranularity(val) },
+	}
+)
+
+// AllDirectives returns all directives defined by the kotlin plugin. This list excludes
+// directives relevant to the Kotlin plugin but not defined by the plugin such as those
+// defined by the rules_jvm plugin.
+func AllDirectives() []GenericDirective {
+	return []GenericDirective{
+		EnabledDirective,
+		OnlyUseExistingLibraryTargetsDirective,
+		LibraryRuleNameSuffix,
+		ExportGranularityDirective,
+	}
+}
+
+func parseEnabledDisableDirective(d rule.Directive) (bool, error) {
+	switch strings.TrimSpace(d.Value) {
+	case "enabled":
+		return true, nil
+	case "disabled":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid directive value %q for key %q: expected enabled or disabled", d.Key, d.Value)
+	}
+}
+
+// ExportGranularity defines valid values for the [ExportGranularityDirective].
+type ExportGranularity string
+
+const (
+	// Package-level identifier resolution. See [ExportGranularityPackage]
+	ExportGranularityPackage = "package"
+	// Identifier resolution.
+	ExportGranularityTopLevelObjects = "top_level_objects"
+)
+
+func parseExportGranularity(d rule.Directive) (ExportGranularity, error) {
+	switch value := ExportGranularity(strings.TrimSpace(d.Value)); value {
+	case ExportGranularityPackage, ExportGranularityTopLevelObjects:
+		return value, nil
+	default:
+		return "", fmt.Errorf("invalid directive value %q for key %q: expected one of {%s, %s}", d.Key, d.Value, ExportGranularityPackage, ExportGranularityTopLevelObjects)
+	}
+}
+
 type KotlinConfig struct {
 	*javaconfig.Config
 
-	generationEnabled bool
+	parent *KotlinConfig
+	rel    string
+
+	librarySuffix    string
+	testFileSuffixes []string
+
+	generationEnabled             bool
+	onlyUseExistingLibraryTargets bool
+
+	exportGranularity ExportGranularity
 }
 
 type Configs = map[string]*KotlinConfig
@@ -20,13 +168,44 @@ func New(repoRoot string) *KotlinConfig {
 	return &KotlinConfig{
 		Config:            javaconfig.New(repoRoot),
 		generationEnabled: true,
+		parent:            nil,
+		testFileSuffixes:  []string{"Test.kt"},
+		librarySuffix:     "_lib",
+		exportGranularity: ExportGranularityPackage,
 	}
 }
 
+// String returns a debug string for the config.
+func (c *KotlinConfig) String() string {
+	return fmt.Sprintf("(KotlinConfig %q: enabled=%v; parent=\n  %s)", c.path(), c.generationEnabled, c.parent)
+}
+
+func (c *KotlinConfig) path() string {
+	if c.parent == nil {
+		return c.rel
+	}
+	return c.rel
+}
+
+// NewChild creates a new child Config. It inherits desired values from the
+// current Config and sets itself as the parent to the child.
 func (c *KotlinConfig) NewChild(childPath string) *KotlinConfig {
 	cCopy := *c
 	cCopy.Config = c.Config.NewChild()
+	cCopy.rel = childPath
+	cCopy.parent = c
+	cCopy.testFileSuffixes = append([]string(nil), c.testFileSuffixes...)
 	return &cCopy
+}
+
+// SetExportGranularity sets the export granularity for the config.
+func (c *KotlinConfig) SetExportGranularity(granularity ExportGranularity) {
+	c.exportGranularity = granularity
+}
+
+// ExportGranularity returns the export granularity for the config.
+func (c *KotlinConfig) ExportGranularity() ExportGranularity {
+	return c.exportGranularity
 }
 
 // SetGenerationEnabled sets whether the extension is enabled or not.
@@ -37,6 +216,41 @@ func (c *KotlinConfig) SetGenerationEnabled(enabled bool) {
 // GenerationEnabled returns whether the extension is enabled or not.
 func (c *KotlinConfig) GenerationEnabled() bool {
 	return c.generationEnabled
+}
+
+// SetOnlyUseExistingLibraryTargets sets the value of the
+// only-use-existing-library-targets configuration value.
+func (c *KotlinConfig) SetOnlyUseExistingLibraryTargets(enabled bool) {
+	c.onlyUseExistingLibraryTargets = enabled
+}
+
+// OnlyUseExistingLibraryTargets returns the value of the
+// only-use-existing-library-targets configuration value.
+func (c *KotlinConfig) OnlyUseExistingLibraryTargets() bool {
+	return c.onlyUseExistingLibraryTargets
+}
+
+// SetLibrarySuffix sets the suffix to be appended to the names of kt_jvm_library
+// targets generated by the plugin.
+func (c *KotlinConfig) SetLibrarySuffix(suffix string) {
+	c.librarySuffix = suffix
+}
+
+// LibrarySuffix returns the suffix of kt_jvm_library targets generated by the
+// plugin.
+func (c *KotlinConfig) LibrarySuffix() string {
+	return c.librarySuffix
+}
+
+// IsTestBaseName reports if the given basename within the same bazel package
+// as the config should be considered a test.
+func (c *KotlinConfig) IsTestBaseName(baseName string) bool {
+	for _, suffix := range c.testFileSuffixes {
+		if strings.HasSuffix(baseName, suffix) {
+			return true
+		}
+	}
+	return false
 }
 
 // ParentForPackage returns the parent Config for the given Bazel package.

--- a/language/kotlin/kotlinconfig/config.go
+++ b/language/kotlin/kotlinconfig/config.go
@@ -24,6 +24,9 @@ type GenericDirective interface {
 	Parse(dir rule.Directive, cfg *KotlinConfig) error
 }
 
+// Directive represents a Gazelle configuration directive for the Kotlin plugin.
+// It maps a specific directive key (e.g. "kotlin_library_suffix") to a parser function
+// and a setter function that updates the KotlinConfig accordingly.
 type Directive[ParsedType any] struct {
 	configKey string
 	parseFn   func(d rule.Directive) (ParsedType, error)

--- a/language/kotlin/kotlinconfig/config.go
+++ b/language/kotlin/kotlinconfig/config.go
@@ -150,6 +150,9 @@ func parseExportGranularity(d rule.Directive) (ExportGranularity, error) {
 	}
 }
 
+// KotlinConfig holds the configuration settings for the Kotlin Gazelle plugin
+// within a specific Bazel package. It embeds the Java configuration and maintains
+// hierarchical inheritance via its parent field.
 type KotlinConfig struct {
 	*javaconfig.Config
 

--- a/language/kotlin/kotlinconfig/config_test.go
+++ b/language/kotlin/kotlinconfig/config_test.go
@@ -1,0 +1,139 @@
+package kotlinconfig_test
+
+import (
+	"testing"
+
+	"github.com/aspect-build/aspect-gazelle/language/kotlin/kotlinconfig"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+func TestDirectives(t *testing.T) {
+	testCases := []struct {
+		name          string
+		directive     rule.Directive
+		expectedError string
+		check         func(t *testing.T, cfg *kotlinconfig.KotlinConfig)
+	}{
+		{
+			name:      "enabled",
+			directive: rule.Directive{Key: "kotlin", Value: "enabled"},
+			check: func(t *testing.T, cfg *kotlinconfig.KotlinConfig) {
+				if !cfg.GenerationEnabled() {
+					t.Errorf("expected GenerationEnabled to be true")
+				}
+			},
+		},
+		{
+			name:      "disabled",
+			directive: rule.Directive{Key: "kotlin", Value: "disabled"},
+			check: func(t *testing.T, cfg *kotlinconfig.KotlinConfig) {
+				if cfg.GenerationEnabled() {
+					t.Errorf("expected GenerationEnabled to be false")
+				}
+			},
+		},
+		{
+			name:      "only_use_existing_library_targets enabled",
+			directive: rule.Directive{Key: "kotlin_only_use_existing_library_targets", Value: "enabled"},
+			check: func(t *testing.T, cfg *kotlinconfig.KotlinConfig) {
+				if !cfg.OnlyUseExistingLibraryTargets() {
+					t.Errorf("expected OnlyUseExistingLibraryTargets to be true")
+				}
+			},
+		},
+		{
+			name:      "only_use_existing_library_targets disabled",
+			directive: rule.Directive{Key: "kotlin_only_use_existing_library_targets", Value: "disabled"},
+			check: func(t *testing.T, cfg *kotlinconfig.KotlinConfig) {
+				if cfg.OnlyUseExistingLibraryTargets() {
+					t.Errorf("expected OnlyUseExistingLibraryTargets to be false")
+				}
+			},
+		},
+		{
+			name:      "library_suffix",
+			directive: rule.Directive{Key: "kotlin_library_suffix", Value: "_custom_suffix"},
+			check: func(t *testing.T, cfg *kotlinconfig.KotlinConfig) {
+				if cfg.LibrarySuffix() != "_custom_suffix" {
+					t.Errorf("expected LibrarySuffix to be '_custom_suffix', got %q", cfg.LibrarySuffix())
+				}
+			},
+		},
+		{
+			name:          "library_suffix invalid",
+			directive:     rule.Directive{Key: "kotlin_library_suffix", Value: "bad suffix"},
+			expectedError: "invalid starlark name part",
+		},
+		{
+			name:      "export_granularity package",
+			directive: rule.Directive{Key: "kotlin_export_granularity", Value: "package"},
+			check: func(t *testing.T, cfg *kotlinconfig.KotlinConfig) {
+				if cfg.ExportGranularity() != kotlinconfig.ExportGranularityPackage {
+					t.Errorf("expected ExportGranularity to be %q, got %q", kotlinconfig.ExportGranularityPackage, cfg.ExportGranularity())
+				}
+			},
+		},
+		{
+			name:      "export_granularity top_level_objects",
+			directive: rule.Directive{Key: "kotlin_export_granularity", Value: "top_level_objects"},
+			check: func(t *testing.T, cfg *kotlinconfig.KotlinConfig) {
+				if cfg.ExportGranularity() != kotlinconfig.ExportGranularityTopLevelObjects {
+					t.Errorf("expected ExportGranularity to be %q, got %q", kotlinconfig.ExportGranularityTopLevelObjects, cfg.ExportGranularity())
+				}
+			},
+		},
+		{
+			name:          "export_granularity invalid",
+			directive:     rule.Directive{Key: "kotlin_export_granularity", Value: "unknown"},
+			expectedError: "invalid directive value",
+		},
+	}
+
+	directivesByKey := make(map[string]kotlinconfig.GenericDirective)
+	for _, dir := range kotlinconfig.AllDirectives() {
+		directivesByKey[dir.ConfigKey()] = dir
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := kotlinconfig.New("workspace")
+			
+			dir, ok := directivesByKey[tc.directive.Key]
+			if !ok {
+				t.Fatalf("unknown directive key %q", tc.directive.Key)
+			}
+
+			err := dir.Parse(tc.directive, cfg)
+			
+			if tc.expectedError != "" {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tc.expectedError)
+				} else if err.Error() == "" || !contains(err.Error(), tc.expectedError) {
+					t.Errorf("expected error containing %q, got %v", tc.expectedError, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tc.check != nil {
+				tc.check(t, cfg)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	// simple helper since strings.Contains is in "strings" package
+	// just to avoid another import or we can import strings.
+	return len(s) >= len(substr) && func() bool {
+		for i := 0; i <= len(s)-len(substr); i++ {
+			if s[i:i+len(substr)] == substr {
+				return true
+			}
+		}
+		return false
+	}()
+}

--- a/language/kotlin/kotlinconfig/config_test.go
+++ b/language/kotlin/kotlinconfig/config_test.go
@@ -33,20 +33,29 @@ func TestDirectives(t *testing.T) {
 			},
 		},
 		{
-			name:      "only_use_existing_library_targets enabled",
-			directive: rule.Directive{Key: "kotlin_only_use_existing_library_targets", Value: "enabled"},
+			name:      "generate_mode package",
+			directive: rule.Directive{Key: "kotlin_generate_mode", Value: "package"},
 			check: func(t *testing.T, cfg *kotlinconfig.KotlinConfig) {
-				if !cfg.OnlyUseExistingLibraryTargets() {
-					t.Errorf("expected OnlyUseExistingLibraryTargets to be true")
+				if cfg.GenerateMode() != kotlinconfig.GenerateModePackage {
+					t.Errorf("expected GenerateMode to be %q, got %q", kotlinconfig.GenerateModePackage, cfg.GenerateMode())
 				}
 			},
 		},
 		{
-			name:      "only_use_existing_library_targets disabled",
-			directive: rule.Directive{Key: "kotlin_only_use_existing_library_targets", Value: "disabled"},
+			name:      "generate_mode file",
+			directive: rule.Directive{Key: "kotlin_generate_mode", Value: "file"},
 			check: func(t *testing.T, cfg *kotlinconfig.KotlinConfig) {
-				if cfg.OnlyUseExistingLibraryTargets() {
-					t.Errorf("expected OnlyUseExistingLibraryTargets to be false")
+				if cfg.GenerateMode() != kotlinconfig.GenerateModeFile {
+					t.Errorf("expected GenerateMode to be %q, got %q", kotlinconfig.GenerateModeFile, cfg.GenerateMode())
+				}
+			},
+		},
+		{
+			name:      "generate_mode existing",
+			directive: rule.Directive{Key: "kotlin_generate_mode", Value: "existing"},
+			check: func(t *testing.T, cfg *kotlinconfig.KotlinConfig) {
+				if cfg.GenerateMode() != kotlinconfig.GenerateModeExisting {
+					t.Errorf("expected GenerateMode to be %q, got %q", kotlinconfig.GenerateModeExisting, cfg.GenerateMode())
 				}
 			},
 		},
@@ -65,26 +74,26 @@ func TestDirectives(t *testing.T) {
 			expectedError: "invalid starlark name part",
 		},
 		{
-			name:      "export_granularity package",
-			directive: rule.Directive{Key: "kotlin_export_granularity", Value: "package"},
+			name:      "resolve_granularity package",
+			directive: rule.Directive{Key: "kotlin_resolve_granularity", Value: "package"},
 			check: func(t *testing.T, cfg *kotlinconfig.KotlinConfig) {
-				if cfg.ExportGranularity() != kotlinconfig.ExportGranularityPackage {
-					t.Errorf("expected ExportGranularity to be %q, got %q", kotlinconfig.ExportGranularityPackage, cfg.ExportGranularity())
+				if cfg.ResolveGranularity() != kotlinconfig.ResolveGranularityPackage {
+					t.Errorf("expected ResolveGranularity to be %q, got %q", kotlinconfig.ResolveGranularityPackage, cfg.ResolveGranularity())
 				}
 			},
 		},
 		{
-			name:      "export_granularity top_level_objects",
-			directive: rule.Directive{Key: "kotlin_export_granularity", Value: "top_level_objects"},
+			name:      "resolve_granularity symbol",
+			directive: rule.Directive{Key: "kotlin_resolve_granularity", Value: "symbol"},
 			check: func(t *testing.T, cfg *kotlinconfig.KotlinConfig) {
-				if cfg.ExportGranularity() != kotlinconfig.ExportGranularityTopLevelObjects {
-					t.Errorf("expected ExportGranularity to be %q, got %q", kotlinconfig.ExportGranularityTopLevelObjects, cfg.ExportGranularity())
+				if cfg.ResolveGranularity() != kotlinconfig.ResolveGranularitySymbol {
+					t.Errorf("expected ResolveGranularity to be %q, got %q", kotlinconfig.ResolveGranularitySymbol, cfg.ResolveGranularity())
 				}
 			},
 		},
 		{
-			name:          "export_granularity invalid",
-			directive:     rule.Directive{Key: "kotlin_export_granularity", Value: "unknown"},
+			name:          "resolve_granularity invalid",
+			directive:     rule.Directive{Key: "kotlin_resolve_granularity", Value: "unknown"},
 			expectedError: "invalid directive value",
 		},
 	}


### PR DESCRIPTION
### Problem
In larger Kotlin codebases, default conventions for target generation and import resolution do not always fit project requirements. By default, Gazelle generates a single library target named after the directory and resolves dependencies at a package level. To provide fine-grained control and support existing build structures, the Kotlin Gazelle extension needs parameters to:
1. Limit dependency resolution/generation only to pre-existing library targets.
2. Customize the suffix used for naming auto-generated Kotlin library targets.
3. Control import/resolve granularity (package-level vs. symbol-level).

### Solution
This PR adds three custom Gazelle configuration directives, along with the necessary parsing, validation, propagation, and configuration architecture in `kotlinconfig/config.go` and `configure.go`:
- `kotlin` (`enabled` | `disabled`)
- `kotlin_generate_mode` (`package` | `file` | `existing`)
- `kotlin_library_suffix` (string)
- `kotlin_resolve_granularity` (`package` | `symbol`)

---

## Directives Specification

### 1. `kotlin`
* **Values**: `enabled` | `disabled`
* **Default**: `enabled`
* **Description**: Controls whether the Kotlin Gazelle extension processes files and generates targets in the current package and its subdirectories.
* **Behavior**:
  - `enabled`: Gazelle scans the directory for `.kt` / `.kts` files, generates rules, and indexes imports.
  - `disabled`: Gazelle completely ignores Kotlin files in this directory and subdirectories.

### 2. `kotlin_generate_mode`
* **Values**: `package` | `file` | `existing`
* **Default**: `package`
* **Description**: Dictates target generation behavior for Kotlin libraries.
* **Behavior**:
  - `package` (Default - Hybrid Mode): Gazelle runs in **automatic target-generation mode** at the package level.
    - If a directory contains Kotlin source files that do not belong to any existing `kt_jvm_library` target, Gazelle automatically constructs and inserts a default library target (named after the directory with suffix) containing those unclaimed files.
    - If some files are already listed in the `srcs` of existing library targets in the `BUILD` file, Gazelle respects those targets, maps those files to the existing targets, and only updates their dependencies, while placing any new or unclaimed files into the default library target.
  - `file` (Hybrid Mode - not yet implemented): Gazelle runs in **automatic target-generation mode** at the file level.
    - For any Kotlin source files that do not belong to any existing `kt_jvm_library` target, Gazelle automatically constructs and inserts a dedicated library target for each file.
    - If a file is already listed in the `srcs` of an existing target, Gazelle respects that target's boundaries and updates its dependencies, rather than generating a redundant file-level target or deleting the existing target.
  - `existing`: Gazelle runs in **strict mode**. It will **never** generate new `kt_jvm_library` targets. Instead, it looks for pre-existing `kt_jvm_library` targets in the `BUILD` file and updates their `deps` based on import analysis of their `srcs`. If a `.kt` file exists in the directory but is not included in the `srcs` of any existing library target, Gazelle will return a fatal error rather than skipping it.
    *Note: Suffix directives have no effect in this mode. To skip files in strict mode, use '# gazelle:exclude <file>' or '.gitignore' to exclude them from Gazelle's visibility.*

### 3. `kotlin_library_suffix`
* **Values**: Any valid Starlark target name string (no spaces, e.g., `_lib`, `-kt`, etc.)
* **Default**: `_lib`
* **Description**: Configures the suffix appended to the folder name to produce the target name for generated `kt_jvm_library` targets.
* **Behavior**:
  - If a package directory is named `utils` and this is set to `-kt`, the generated target name will be `utils-kt`.

### 4. `kotlin_resolve_granularity`
* **Values**: `package` | `symbol`
* **Default**: `package` (to be updated to `symbol`)
* **Description**: Defines how the Gazelle import index associates Kotlin source files and their exported symbols with Bazel targets.
* **Scope of Effect**:
  - **Starlark Rule Generation**: **Not affected**. The generated `BUILD.bazel` target structure, `srcs`, and visual attributes remain identical regardless of this setting.
  - **Dependency Resolution**: **Directly affected**. This directive controls how the target is registered in the global Gazelle index. When a consumer target imports a symbol, the resolution path is determined by the resolve granularity set on the **defining (exporting) target**, which dictates whether Gazelle resolves dependencies by matching package namespaces or exact top-level declaration names.
* **Behavior & Motivation**:
  - `package`: **Package-level resolution**. The plugin indexes only the package statement (e.g. `package com.example.hello`) of each source file and maps that package name to the target containing the file.
  - `symbol`: **Symbol-level resolution**. The plugin parses and indexes the exact fully-qualified names of all **top-level declarations** within each file. Unlike Java, Kotlin supports a variety of top-level constructs, all of which are indexed under this mode:
    - Classes (`class`)
    - Interfaces (`interface`)
    - Singleton Objects (`object`)
    - Top-level Functions (`fun`)
    - Top-level Properties / Variables / Constants (`val`, `var`, `const val`)
    - Type aliases (`typealias`)

---

## Implementation Details & How it Works

> [!WARNING]
> **Implementation Status**:
> While this PR introduces the configuration schema representation, registration, validation, parsing, hierarchical inheritance, and unit testing of these custom directives, **they are not yet functionally wired to the rule generation or dependency resolution engines** (in `generate.go` and `resolver.go`) in this specific commit.
>
> The full wiring and implementation is stacked as follows:
> - **[PR #410](https://github.com/aspect-build/aspect-gazelle/pull/410)**: Upgrades the parser to query and extract package metadata, entry points, and top-level declarations.
> - **[PR #411](https://github.com/aspect-build/aspect-gazelle/pull/411)**: Upgrades the dependency resolver to handle recursive parent packages.
> - **[PR #412](https://github.com/aspect-build/aspect-gazelle/pull/412)**: Adds protobuf integration tests.
> - **[PR #413](https://github.com/aspect-build/aspect-gazelle/pull/413)**: Adds test target generation support.
> - **[PR #414](https://github.com/aspect-build/aspect-gazelle/pull/414)**: Fully wires up resolution and generation support locally, including `kotlin_generate_mode` and multiple target packages.

1. **Directive Representation**:
   - Directives are modeled in `kotlinconfig/config.go` using a type-safe generic `Directive[ParsedType any]` struct. This struct holds the directive key, a parsing function `parseFn` that converts the string value to its typed representation, and a setter function `setFn` that applies the parsed value to a `KotlinConfig` instance.
2. **Registration and Lifecycle**:
   - The plugin registers all directives in `kotlinconfig.AllDirectives()`.
   - In `language/kotlin/configure.go`, `directivesByKey` is built during package `init()` to map directive keys to their implementations.
   - The plugin implements Gazelle's `KnownDirectives()` method to declare the custom directive keys to Gazelle's main runner.
3. **Parsing and Propagation**:
   - As Gazelle traverses package directories recursively, `Configure` receives directive configurations from the `BUILD` files via comments (e.g. `# gazelle:kotlin_generate_mode existing`).
   - If a subdirectory does not define a directive, it inherits the configuration of its parent directory. This inheritance is established by cloned configuration frames during tree traversal (implemented via `NewChild()`).
4. **Validation and Error Handling**:
   - Directive values are strictly validated. If a directive specifies an invalid value, the plugin logs a fatal error using `BazelLog.Fatalf()`, forcing the developer to provide correct configuration parameters.

---

## Verification Plan

### Automated Tests
To run the directive configuration parser tests, execute:
```bash
bazel test //kotlinconfig:kotlinconfig_test
```
This runs the comprehensive suite in `kotlinconfig/config_test.go` checking inheritance, directive mapping, value boundaries, and error validation for:
- **`kotlin`**: Verified with `enabled` / `disabled` configurations.
- **`kotlin_generate_mode`**: Tested with `package`, `file`, and `existing` inputs.
- **`kotlin_library_suffix`**: Validated with correct Starlark string naming conventions and ensuring space characters reject correctly.
- **`kotlin_resolve_granularity`**: Tested with `package` and `symbol` configurations.

---
Part of https://github.com/aspect-build/aspect-gazelle/issues/151
