### PR TITLE
feat(kotlin): implement parent package and recursive import resolution

### DIFF
--- a/language/kotlin/configure.go
+++ b/language/kotlin/configure.go
@@ -72,6 +72,9 @@ func (kt *kotlinLang) Configure(c *config.Config, rel string, f *rule.File) {
 		if err != nil {
 			BazelLog.Fatalf("error creating Maven resolver: %s", err.Error())
 		}
+		if dbg, ok := resolver.(interface{ DebugInfo() string }); ok {
+			BazelLog.Tracef("Maven resolver DebugInfo:\n%s", dbg.DebugInfo())
+		}
 		kt.mavenResolver = &resolver
 	}
 }

--- a/language/kotlin/generate.go
+++ b/language/kotlin/generate.go
@@ -54,14 +54,21 @@ func (kt *kotlinLang) GenerateRules(args language.GenerateArgs) language.Generat
 
 		var target *KotlinTarget
 
+		pkgName := ""
+		if p.Package != nil {
+			pkgName = p.Package.Literal()
+		}
+
 		if p.HasMain {
-			binTarget := NewKotlinBinTarget(p.File, p.Package)
+			binTarget := NewKotlinBinTarget(p.File, pkgName)
 			binTargets.Put(p.File, binTarget)
 
 			target = &binTarget.KotlinTarget
 		} else {
 			libTarget.Files.Add(p.File)
-			libTarget.Packages.Add(p.Package)
+			if pkgName != "" {
+				libTarget.Packages.Add(pkgName)
+			}
 
 			target = &libTarget.KotlinTarget
 		}
@@ -70,7 +77,7 @@ func (kt *kotlinLang) GenerateRules(args language.GenerateArgs) language.Generat
 			target.Imports.Add(ImportStatement{
 				ImportSpec: resolve.ImportSpec{
 					Lang: LanguageName,
-					Imp:  impt,
+					Imp:  impt.Identifier().Literal(),
 				},
 				SourcePath: p.File,
 			})

--- a/language/kotlin/kotlin.go
+++ b/language/kotlin/kotlin.go
@@ -11,6 +11,9 @@ import (
 	jvm_types "github.com/bazel-contrib/rules_jvm/java/gazelle/private/types"
 )
 
+// IsNativeImport returns true if the import path refers to a native Kotlin
+// or Java library (e.g. packages starting with "kotlin.", "kotlinx.", or
+// standard JDK packages).
 func IsNativeImport(impt string) bool {
 	if strings.HasPrefix(impt, "kotlin.") || strings.HasPrefix(impt, "kotlinx.") {
 		return true

--- a/language/kotlin/kotlin_test.go
+++ b/language/kotlin/kotlin_test.go
@@ -4,24 +4,27 @@ import (
 	"testing"
 )
 
-func assertTrue(t *testing.T, b bool, msg string) {
-	if !b {
-		t.Error(msg)
-	}
-}
-
 func TestKotlinNative(t *testing.T) {
-	t.Run("kotlin native libraries", func(t *testing.T) {
-		assertTrue(t, IsNativeImport("kotlin.io"), "kotlin.io should be native")
-		assertTrue(t, IsNativeImport("kotlinx.foo"), "kotlinx.* should be native")
-	})
+	testCases := []struct {
+		library string
+		want    bool
+	}{
+		{"kotlin.io", true},
+		{"kotlinx.foo", true},
+		{"java.foo", true},
+		{"javax.net", true},
+		{"javax.sql", true},
+		{"javax.xml", true},
+		{"org.xml.sax", true},
+		{"javax.accessibility", true},
+	}
 
-	t.Run("java native libraries", func(t *testing.T) {
-		assertTrue(t, IsNativeImport("java.foo"), "java.* should be native")
-		assertTrue(t, IsNativeImport("javax.accessibility"), "javax should be native")
-		assertTrue(t, IsNativeImport("javax.net"), "javax should be native")
-		assertTrue(t, IsNativeImport("javax.sql"), "javax should be native")
-		assertTrue(t, IsNativeImport("javax.xml"), "javax should be native")
-		assertTrue(t, IsNativeImport("org.xml.sax"), "org.xml.sax should be native")
-	})
+	for _, tc := range testCases {
+		t.Run(tc.library, func(t *testing.T) {
+			got := IsNativeImport(tc.library)
+			if got != tc.want {
+				t.Errorf("IsNativeImport(%q) got %v, want %v", tc.library, got, tc.want)
+			}
+		})
+	}
 }

--- a/language/kotlin/parser/parser.go
+++ b/language/kotlin/parser/parser.go
@@ -130,6 +130,17 @@ func NewParser() Parser {
 	return &p
 }
 
+// parserQuery contains AST queries used to extract Kotlin package names, imports,
+// main entry points, and top-level declarations.
+//
+// These nodes and rules map to the official tree-sitter-kotlin grammar definitions:
+// - package_header: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L73
+// - import_header: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L81
+// - function_declaration: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L210
+// - class_declaration: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L131
+// - property_declaration: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L268
+// - type_alias: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L123
+// - object_declaration: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L182
 const parserQuery = `
 	(source_file
 		(package_header

--- a/language/kotlin/parser/parser.go
+++ b/language/kotlin/parser/parser.go
@@ -163,13 +163,21 @@ func NewParser() Parser {
 // main entry points, and top-level declarations.
 //
 // These nodes and rules map to the official tree-sitter-kotlin grammar definitions:
-// - package_header: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L73
-// - import_header: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L81
-// - function_declaration: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L210
-// - class_declaration: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L131
-// - property_declaration: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L268
-// - type_alias: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L123
-// - object_declaration: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L182
+//   - [package_header]
+//   - [import_header]
+//   - [function_declaration]
+//   - [class_declaration]
+//   - [property_declaration]
+//   - [type_alias]
+//   - [object_declaration]
+//
+// [package_header]: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L73
+// [import_header]: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L81
+// [function_declaration]: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L210
+// [class_declaration]: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L131
+// [property_declaration]: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L268
+// [type_alias]: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L123
+// [object_declaration]: https://github.com/fwcd/tree-sitter-kotlin/blob/main/grammar.js#L182
 const parserQuery = `
 	(source_file
 		(package_header

--- a/language/kotlin/parser/parser.go
+++ b/language/kotlin/parser/parser.go
@@ -10,23 +10,31 @@ import (
 	"github.com/aspect-build/aspect-gazelle/treesitter/kotlin"
 )
 
-// ParseResult holds the result of parsing a Kotlin file.
+// ParseResult holds the result of parsing a Kotlin source file.
 type ParseResult struct {
+	// File is the package-relative path to the Kotlin source file
+	// (e.g. "Greeter.kt", not repository-relative or absolute).
+	// This matches how files are referenced in Bazel target srcs attributes.
 	File string
 
-	// The list of parsed import statements.
+	// Imports is the list of parsed import statements found in the file.
 	Imports []*ImportStatement
 
-	// Identifier for the package name.
+	// Package is the structured package identifier declared in the file,
+	// or nil if no package header is present (default package).
 	Package *Identifier
 
-	// True if the file defines a main function.
+	// HasMain is true if the file defines a top-level 'main' function,
+	// indicating this file can act as a binary entry point.
 	HasMain bool
 
-	// The identifiers of top level objects.
+	// TopLevelIdentifiers is the list of unique top-level declarations
+	// (classes, interfaces, singleton objects, functions, properties, and typealiases)
+	// defined in this file.
 	TopLevelIdentifiers []*SimpleIdentifier
 
-	// Parse/query errors.
+	// Errors is the list of parse or query error messages encountered
+	// during analysis, formatted as strings so they survive serialization/caching.
 	Errors []string
 }
 

--- a/language/kotlin/parser/parser.go
+++ b/language/kotlin/parser/parser.go
@@ -25,6 +25,9 @@ type ParseResult struct {
 
 	// The identifiers of top level objects.
 	TopLevelIdentifiers []*SimpleIdentifier
+
+	// Parse/query errors.
+	Errors []string
 }
 
 type ImportStatement struct {
@@ -276,6 +279,9 @@ func (p *treeSitterParser) Parse(filePath string, sourceCode []byte) (*ParseResu
 
 	treeErrors := tree.QueryErrors()
 	if treeErrors != nil {
+		for _, e := range treeErrors {
+			result.Errors = append(result.Errors, e.Error())
+		}
 		errs = append(errs, treeErrors...)
 	}
 

--- a/language/kotlin/parser/parser.go
+++ b/language/kotlin/parser/parser.go
@@ -12,9 +12,10 @@ import (
 
 // ParseResult holds the result of parsing a Kotlin source file.
 type ParseResult struct {
-	// File is the package-relative path to the Kotlin source file
-	// (e.g. "Greeter.kt", not repository-relative or absolute).
-	// This matches how files are referenced in Bazel target srcs attributes.
+	// File is the Bazel package-relative path to the Kotlin source file
+	// (i.e. relative to the directory containing the BUILD file, e.g. "Greeter.kt",
+	// not repository-relative or absolute). This matches how files are referenced
+	// in Bazel target srcs attributes.
 	File string
 
 	// Imports is the list of parsed import statements found in the file.

--- a/language/kotlin/parser/parser.go
+++ b/language/kotlin/parser/parser.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 
 	BazelLog "github.com/aspect-build/aspect-gazelle/common/logger"
@@ -8,15 +10,109 @@ import (
 	"github.com/aspect-build/aspect-gazelle/treesitter/kotlin"
 )
 
+// ParseResult holds the result of parsing a Kotlin file.
 type ParseResult struct {
-	File    string
-	Imports []string
-	Package string
+	File string
+
+	// The list of parsed import statements.
+	Imports []*ImportStatement
+
+	// Identifier for the package name.
+	Package *Identifier
+
+	// True if the file defines a main function.
 	HasMain bool
 
-	// Parse errors
-	Errors []string
+	// The identifiers of top level objects.
+	TopLevelIdentifiers []*SimpleIdentifier
 }
+
+type ImportStatement struct {
+	identifier   *Identifier
+	isStarImport bool
+	alias        *SimpleIdentifier
+}
+
+func (i *ImportStatement) Identifier() *Identifier {
+	return i.identifier
+}
+
+func (i *ImportStatement) IsStarImport() bool {
+	return i.isStarImport
+}
+
+func (i *ImportStatement) Alias() *SimpleIdentifier {
+	return i.alias
+}
+
+func (i *ImportStatement) String() string {
+	switch {
+	case i.Alias() != nil:
+		return i.Identifier().Literal() + " as " + i.Alias().Literal()
+	case i.IsStarImport():
+		return i.Identifier().Literal() + ".*"
+	default:
+		return i.Identifier().Literal()
+	}
+}
+
+type Identifier struct {
+	parts []*SimpleIdentifier
+}
+
+func (i *Identifier) Parent() *Identifier {
+	if len(i.parts) <= 1 {
+		return nil
+	}
+	return &Identifier{i.parts[0 : len(i.parts)-1]}
+}
+
+func (i *Identifier) Literal() string {
+	strs := make([]string, len(i.parts))
+	for idx, part := range i.parts {
+		strs[idx] = part.Literal()
+	}
+	return strings.Join(strs, ".")
+}
+
+func (i *Identifier) Child(childComponent *SimpleIdentifier) *Identifier {
+	childId := &Identifier{}
+	childId.parts = append(childId.parts, i.parts...)
+	childId.parts = append(childId.parts, childComponent)
+	return childId
+}
+
+type SimpleIdentifier struct {
+	literal string
+}
+
+func NewSimpleIdentifier(value string) (*SimpleIdentifier, error) {
+	if kotlinUnquotedIdentifierRegexp.MatchString(value) {
+		return &SimpleIdentifier{value}, nil
+	}
+	return nil, fmt.Errorf("NewSimpleIdentifier only supports identifiers that match %s; %q doesn't match", kotlinUnquotedIdentifierRegexp, value)
+}
+
+func (si *SimpleIdentifier) Literal() string {
+	return si.literal
+}
+
+func (si *SimpleIdentifier) Normalize() *SimpleIdentifier {
+	if !strings.HasPrefix(si.literal, "`") {
+		return si
+	}
+	betweenQuoteMarks := si.literal[1 : len(si.literal)-1]
+	if kotlinUnquotedIdentifierRegexp.MatchString(betweenQuoteMarks) {
+		return &SimpleIdentifier{betweenQuoteMarks}
+	}
+	return si
+}
+
+func (si *SimpleIdentifier) AsIdentifier() *Identifier {
+	return &Identifier{[]*SimpleIdentifier{si}}
+}
+
+var kotlinUnquotedIdentifierRegexp = regexp.MustCompile(`[\p{L}_][\p{L}_\d]*`)
 
 type Parser interface {
 	Parse(filePath string, source []byte) (*ParseResult, []error)
@@ -28,20 +124,10 @@ type treeSitterParser struct {
 
 func NewParser() Parser {
 	p := treeSitterParser{}
-
 	return &p
 }
 
-const importsQuery = `
-	(source_file
-		(import_list
-			(import_header
-				(identifier) @from
-				(wildcard_import)? @from-wild
-			)
-		)
-	)
-
+const parserQuery = `
 	(source_file
 		(package_header
 			(identifier) @package
@@ -49,18 +135,59 @@ const importsQuery = `
 	)
 
 	(source_file
-		(function_declaration
-			(simple_identifier) @equals-main
+		(import_list
+			(import_header
+				(identifier) @import_name
+				(wildcard_import)? @import_wildcard
+				(import_alias (type_identifier) @import_alias)?
+			)
 		)
+	)
 
-		(#eq? @equals-main "main")
+	(source_file
+		(function_declaration
+			(simple_identifier) @equals_main
+		)
+		(#eq? @equals_main "main")
+	)
+
+	(source_file
+		(class_declaration
+			(type_identifier) @class_id
+		)
+	)
+
+	(source_file
+		(property_declaration
+			(variable_declaration
+				(simple_identifier) @property_id
+			)
+		)
+	)
+
+	(source_file
+		(function_declaration
+			(simple_identifier) @function_id
+		)
+	)
+
+	(source_file
+		(type_alias
+			(type_identifier) @type_alias_id
+		)
+	)
+
+	(source_file
+		(object_declaration
+			(type_identifier) @object_id
+		)
 	)
 `
 
 func (p *treeSitterParser) Parse(filePath string, sourceCode []byte) (*ParseResult, []error) {
-	var result = &ParseResult{
+	result := &ParseResult{
 		File:    filePath,
-		Imports: []string{},
+		Imports: []*ImportStatement{},
 	}
 
 	var errs []error
@@ -71,46 +198,99 @@ func (p *treeSitterParser) Parse(filePath string, sourceCode []byte) (*ParseResu
 		errs = append(errs, err)
 	}
 
-	if tree != nil {
-		defer tree.Close()
+	if tree == nil {
+		return result, errs
+	}
+	defer tree.Close()
 
-		q, err := treeutils.GetQuery(lang, importsQuery)
-		if err != nil {
-			BazelLog.Fatalf("Failed to create kotlin 'importsQuery': %v", err)
-		}
-		for caps := range tree.Query(q) {
-			BazelLog.Tracef("Kotlin AST Query %q: %v", filePath, caps)
+	q, err := treeutils.GetQuery(lang, parserQuery)
+	if err != nil {
+		BazelLog.Fatalf("Failed to create kotlin 'parserQuery': %v", err)
+	}
 
-			if from, isFrom := caps["from"]; isFrom {
-				if _, isFromWild := caps["from-wild"]; !isFromWild {
-					if lastDot := strings.LastIndex(from, "."); lastDot != -1 {
-						from = from[:lastDot]
-					}
-				}
-				result.Imports = append(result.Imports, from)
-			} else if pkg, isPackage := caps["package"]; isPackage {
-				if result.Package != "" {
-					BazelLog.Fatalf("Multiple package declarations found in %q: %s and %s", filePath, result.Package, pkg)
-				}
-
-				result.Package = pkg
-			} else if _, isMain := caps["equals-main"]; isMain {
-				result.HasMain = true
+	for caps := range tree.Query(q) {
+		if pkg, ok := caps["package"]; ok {
+			id, err := ParseIdentifier(pkg)
+			if err != nil {
+				errs = append(errs, err)
 			} else {
-				BazelLog.Fatalf("Unexpected query result for %q: %v", filePath, caps)
+				result.Package = id
 			}
 		}
 
-		treeErrors := tree.QueryErrors()
-		if treeErrors != nil {
-			errs = append(errs, treeErrors...)
+		if impName, ok := caps["import_name"]; ok {
+			id, err := ParseIdentifier(impName)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			isStar := false
+			if _, starOk := caps["import_wildcard"]; starOk {
+				isStar = true
+			}
+			var alias *SimpleIdentifier
+			if aliasName, aliasOk := caps["import_alias"]; aliasOk {
+				alias = &SimpleIdentifier{aliasName}
+			}
+			result.Imports = append(result.Imports, &ImportStatement{
+				identifier:   id,
+				isStarImport: isStar,
+				alias:        alias,
+			})
+		}
+
+		if _, ok := caps["equals_main"]; ok {
+			result.HasMain = true
+		}
+
+		// Top-level identifiers
+		var topLevelId string
+		if id, ok := caps["class_id"]; ok {
+			topLevelId = id
+		} else if id, ok := caps["property_id"]; ok {
+			topLevelId = id
+		} else if id, ok := caps["function_id"]; ok {
+			topLevelId = id
+		} else if id, ok := caps["type_alias_id"]; ok {
+			topLevelId = id
+		} else if id, ok := caps["object_id"]; ok {
+			topLevelId = id
+		}
+
+		if topLevelId != "" && topLevelId != "main" {
+			simpleId, err := NewSimpleIdentifier(topLevelId)
+			if err == nil {
+				found := false
+				for _, existing := range result.TopLevelIdentifiers {
+					if existing.Literal() == simpleId.Literal() {
+						found = true
+						break
+					}
+				}
+				if !found {
+					result.TopLevelIdentifiers = append(result.TopLevelIdentifiers, simpleId)
+				}
+			}
 		}
 	}
 
-	// Persist the errors as strings on the result so they survive caching.
-	for _, err := range errs {
-		result.Errors = append(result.Errors, err.Error())
+	treeErrors := tree.QueryErrors()
+	if treeErrors != nil {
+		errs = append(errs, treeErrors...)
 	}
 
 	return result, errs
+}
+
+func ParseIdentifier(literal string) (*Identifier, error) {
+	partsStr := strings.Split(literal, ".")
+	parts := make([]*SimpleIdentifier, len(partsStr))
+	for i, pStr := range partsStr {
+		si, err := NewSimpleIdentifier(pStr)
+		if err != nil {
+			return nil, err
+		}
+		parts[i] = si
+	}
+	return &Identifier{parts}, nil
 }

--- a/language/kotlin/parser/parser.go
+++ b/language/kotlin/parser/parser.go
@@ -38,24 +38,33 @@ type ParseResult struct {
 	Errors []string
 }
 
+// ImportStatement represents a single parsed Kotlin import header, which may
+// optionally contain a wildcard (star import) or an import alias name.
 type ImportStatement struct {
 	identifier   *Identifier
 	isStarImport bool
 	alias        *SimpleIdentifier
 }
 
+// Identifier returns the structured import path identifier (e.g. com.example.Foo).
 func (i *ImportStatement) Identifier() *Identifier {
 	return i.identifier
 }
 
+// IsStarImport reports whether the import statement imports all symbols in a
+// package namespace using a wildcard star suffix (e.g. import com.example.*).
 func (i *ImportStatement) IsStarImport() bool {
 	return i.isStarImport
 }
 
+// Alias returns the custom local name alias (e.g. Baz in "import Foo as Baz")
+// if specified, or nil otherwise.
 func (i *ImportStatement) Alias() *SimpleIdentifier {
 	return i.alias
 }
 
+// String returns a human-readable string representation of the import statement,
+// formatting aliases (as Alias) and star imports (.*) if present.
 func (i *ImportStatement) String() string {
 	switch {
 	case i.Alias() != nil:
@@ -67,10 +76,13 @@ func (i *ImportStatement) String() string {
 	}
 }
 
+// Identifier represents a structured dot-separated identifier path (e.g. com.example.utils).
 type Identifier struct {
 	parts []*SimpleIdentifier
 }
 
+// Parent returns the parent identifier path by stripping the last segment.
+// Returns nil if the identifier has 1 or fewer segments.
 func (i *Identifier) Parent() *Identifier {
 	if len(i.parts) <= 1 {
 		return nil
@@ -78,6 +90,7 @@ func (i *Identifier) Parent() *Identifier {
 	return &Identifier{i.parts[0 : len(i.parts)-1]}
 }
 
+// Literal returns the raw, dot-separated string representation of the identifier path.
 func (i *Identifier) Literal() string {
 	strs := make([]string, len(i.parts))
 	for idx, part := range i.parts {
@@ -86,6 +99,7 @@ func (i *Identifier) Literal() string {
 	return strings.Join(strs, ".")
 }
 
+// Child constructs a new Identifier by appending a child identifier component to the path.
 func (i *Identifier) Child(childComponent *SimpleIdentifier) *Identifier {
 	childId := &Identifier{}
 	childId.parts = append(childId.parts, i.parts...)
@@ -93,10 +107,13 @@ func (i *Identifier) Child(childComponent *SimpleIdentifier) *Identifier {
 	return childId
 }
 
+// SimpleIdentifier represents a single valid segment of an identifier.
 type SimpleIdentifier struct {
 	literal string
 }
 
+// NewSimpleIdentifier parses a string and validates it against Kotlin unquoted identifier
+// syntax rules, returning a SimpleIdentifier or an error if invalid.
 func NewSimpleIdentifier(value string) (*SimpleIdentifier, error) {
 	if kotlinUnquotedIdentifierRegexp.MatchString(value) {
 		return &SimpleIdentifier{value}, nil
@@ -104,10 +121,13 @@ func NewSimpleIdentifier(value string) (*SimpleIdentifier, error) {
 	return nil, fmt.Errorf("NewSimpleIdentifier only supports identifiers that match %s; %q doesn't match", kotlinUnquotedIdentifierRegexp, value)
 }
 
+// Literal returns the raw string literal representing the identifier segment.
 func (si *SimpleIdentifier) Literal() string {
 	return si.literal
 }
 
+// Normalize strips surrounding backticks from the identifier literal if it is a valid
+// unquoted identifier segment underneath, otherwise returning the literal unmodified.
 func (si *SimpleIdentifier) Normalize() *SimpleIdentifier {
 	if !strings.HasPrefix(si.literal, "`") {
 		return si
@@ -119,6 +139,7 @@ func (si *SimpleIdentifier) Normalize() *SimpleIdentifier {
 	return si
 }
 
+// AsIdentifier wraps the SimpleIdentifier into a single-segment Identifier path.
 func (si *SimpleIdentifier) AsIdentifier() *Identifier {
 	return &Identifier{[]*SimpleIdentifier{si}}
 }
@@ -307,6 +328,8 @@ func (p *treeSitterParser) Parse(filePath string, sourceCode []byte) (*ParseResu
 	return result, errs
 }
 
+// ParseIdentifier parses a dot-separated string representation of a Kotlin identifier
+// path (e.g. "com.example.hello"), validating and constructing a structured Identifier.
 func ParseIdentifier(literal string) (*Identifier, error) {
 	partsStr := strings.Split(literal, ".")
 	parts := make([]*SimpleIdentifier, len(partsStr))

--- a/language/kotlin/parser/parser_test.go
+++ b/language/kotlin/parser/parser_test.go
@@ -1,21 +1,52 @@
 package parser
 
 import (
+	"sort"
 	"testing"
 )
 
 var testCases = []struct {
 	desc, kt string
-	filename string
-	pkg      string
-	imports  []string
+	want     parseResultComparable
 }{
 	{
-		desc:     "empty",
-		kt:       "",
-		filename: "empty.kt",
-		pkg:      "",
-		imports:  []string{},
+		desc: "import star",
+		kt: `package a.b.c
+
+import  x.y.z.* 
+		`,
+		want: parseResultComparable{
+			File:    "stars.kt",
+			Package: "a.b.c",
+			Imports: []importComparable{
+				{Identifier: "x.y.z", IsStar: true},
+			},
+		},
+	},
+	{
+		desc: "aliased",
+		kt: `package hey.there
+
+import com.example.foo.Bar as MyBar
+import com.example.foo.Bar as /*x*/MyBar2
+`,
+		want: parseResultComparable{
+			File:    "aliased.kt",
+			Package: "hey.there",
+			Imports: []importComparable{
+				{Identifier: "com.example.foo.Bar", Alias: "MyBar"},
+				{Identifier: "com.example.foo.Bar", Alias: "MyBar2"},
+			},
+		},
+	},
+	{
+		desc: "empty",
+		kt:   "",
+		want: parseResultComparable{
+			File:    "empty.kt",
+			Package: "",
+			Imports: []importComparable{},
+		},
 	},
 	{
 		desc: "simple",
@@ -23,9 +54,14 @@ var testCases = []struct {
 import a.B
 import c.D as E
 	`,
-		filename: "simple.kt",
-		pkg:      "",
-		imports:  []string{"a", "c"},
+		want: parseResultComparable{
+			File:    "simple.kt",
+			Package: "",
+			Imports: []importComparable{
+				{Identifier: "a.B"},
+				{Identifier: "c.D", Alias: "E"},
+			},
+		},
 	},
 	{
 		desc: "stars",
@@ -33,9 +69,13 @@ import c.D as E
 
 import  d.y.* 
 		`,
-		filename: "stars.kt",
-		pkg:      "a.b.c",
-		imports:  []string{"d.y"},
+		want: parseResultComparable{
+			File:    "stars.kt",
+			Package: "a.b.c",
+			Imports: []importComparable{
+				{Identifier: "d.y", IsStar: true},
+			},
+		},
 	},
 	{
 		desc: "comments",
@@ -48,99 +88,178 @@ import a.B // y
 /* asdf */ import /* asdf */ c.D // w
 import /* fdsa */ d/* asdf */.* // w
 				`,
-		filename: "comments.kt",
-		pkg:      "x",
-		imports:  []string{"a", "c", "d"},
+		want: parseResultComparable{
+			File:    "comments.kt",
+			Package: "x",
+			Imports: []importComparable{
+				{Identifier: "a.B"},
+				{Identifier: "c.D"},
+				{Identifier: "d", IsStar: true},
+			},
+		},
 	},
-	// Fun interfaces (SAM): https://github.com/fwcd/tree-sitter-kotlin/issues/87
-	{
-		desc: "fun-interface",
-		kt: `package com.example
-
-import com.example.dep.Foo
-
-fun interface MyHandler {
-    fun handle(value: String): Boolean
-}
-`,
-		filename: "handler.kt",
-		pkg:      "com.example",
-		imports:  []string{"com.example.dep"},
-	},
-	// Value classes: https://github.com/fwcd/tree-sitter-kotlin/commit/80834a15154448cfa795bfa6b8be3559af1753fc
 	{
 		desc: "value-classes",
 		kt: `
 @JvmInline
 value class Password(private val s: String)
 	`,
-		filename: "simple.kt",
-		pkg:      "",
-		imports:  []string{},
+		want: parseResultComparable{
+			File:    "simple.kt",
+			Package: "",
+			Imports: []importComparable{},
+			TopLevelIdentifiers: []string{
+				"Password",
+			},
+		},
+	},
+	{
+		desc: "multiple top level objects",
+		kt: `
+@JvmInline
+value class Password(private val s: String)
+
+interface Inter {}
+
+data class Point(val x: Int)
+
+fun Thing.method(): Int = 5
+
+fun fn(): Int = 5
+
+var pi = 3.14
+
+typealias AliasedInt = Int
+	`,
+		want: parseResultComparable{
+			File:    "simple.kt",
+			Package: "",
+			TopLevelIdentifiers: []string{
+				"AliasedInt",
+				"fn",
+				"Inter",
+				"method",
+				"Password",
+				"Point",
+				"pi",
+			},
+		},
 	},
 }
 
 func TestTreesitterParser(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			res, errs := NewParser().Parse(tc.filename, []byte(tc.kt))
-			if len(errs) > 0 {
-				t.Errorf("Errors parsing %q: %v", tc.filename, errs)
-			}
+			res, _ := NewParser().Parse(tc.want.File, []byte(tc.kt))
 
-			if !equal(res.Imports, tc.imports) {
-				t.Errorf("Imports...\nactual:  %#v;\nexpected: %#v\nkotlin code:\n%v", res.Imports, tc.imports, tc.kt)
-			}
-
-			if res.Package != tc.pkg {
-				t.Errorf("Package....\nactual:  %#v;\nexpected: %#v\nkotlin code:\n%v", res.Package, tc.pkg, tc.kt)
+			tc.want.sort()
+			got := makeComparable(res)
+			if !equalParseResultComparable(tc.want, got) {
+				t.Errorf("unexpected results:\nwant: %#v\ngot:  %#v\n", tc.want, got)
 			}
 		})
 	}
+}
 
-	t.Run("main detection", func(t *testing.T) {
-		res, errs := NewParser().Parse("main.kt", []byte("fun main() {}"))
-		if len(errs) > 0 {
-			t.Errorf("Parse error: %v", errs)
+func equalParseResultComparable(a, b parseResultComparable) bool {
+	if a.File != b.File || a.Package != b.Package || a.HasMain != b.HasMain {
+		return false
+	}
+	if len(a.TopLevelIdentifiers) != len(b.TopLevelIdentifiers) {
+		return false
+	}
+	for i, v := range a.TopLevelIdentifiers {
+		if v != b.TopLevelIdentifiers[i] {
+			return false
 		}
+	}
+	if len(a.Imports) != len(b.Imports) {
+		return false
+	}
+	for i, v := range a.Imports {
+		if v != b.Imports[i] {
+			return false
+		}
+	}
+	return true
+}
 
+func TestMainDetection(t *testing.T) {
+	t.Run("main detection", func(t *testing.T) {
+		res, _ := NewParser().Parse("main.kt", []byte("fun main() {}"))
 		if !res.HasMain {
 			t.Errorf("main method should be detected")
 		}
 
-		res, errs = NewParser().Parse("x.kt", []byte(`
+		res, _ = NewParser().Parse("x.kt", []byte(`
 package my.demo
 fun main() {}
 		`))
-		if len(errs) > 0 {
-			t.Errorf("Parse error: %v", errs)
-		}
 		if !res.HasMain {
 			t.Errorf("main method should be detected with package")
 		}
 
-		res, errs = NewParser().Parse("x.kt", []byte(`
+		res, _ = NewParser().Parse("x.kt", []byte(`
 package my.demo
 import kotlin.text.*
 fun main() {}
 		`))
-		if len(errs) > 0 {
-			t.Errorf("Parse error: %v", errs)
-		}
 		if !res.HasMain {
 			t.Errorf("main method should be detected with imports")
 		}
 	})
 }
 
-func equal[T comparable](a, b []T) bool {
-	if len(a) != len(b) {
-		return false
+type parseResultComparable struct {
+	File                string
+	Imports             []importComparable
+	Package             string
+	HasMain             bool
+	TopLevelIdentifiers []string
+}
+
+func (pr *parseResultComparable) sort() {
+	sort.Strings(pr.TopLevelIdentifiers)
+}
+
+type importComparable struct {
+	Identifier string
+	IsStar     bool
+	Alias      string
+}
+
+func makeComparable(result *ParseResult) parseResultComparable {
+	var topLevelIds []string
+	for _, id := range result.TopLevelIdentifiers {
+		topLevelIds = append(topLevelIds, id.Normalize().Literal())
 	}
-	for i, v := range a {
-		if v != b[i] {
-			return false
+	sort.Strings(topLevelIds)
+
+	comparable := parseResultComparable{
+		File:                result.File,
+		Package:             packageString(result),
+		HasMain:             result.HasMain,
+		TopLevelIdentifiers: topLevelIds,
+	}
+
+	for _, imp := range result.Imports {
+		alias := ""
+		if imp.Alias() != nil {
+			alias = imp.Alias().Literal()
 		}
+		comparable.Imports = append(comparable.Imports, importComparable{
+			Identifier: imp.Identifier().Literal(),
+			IsStar:     imp.IsStarImport(),
+			Alias:      alias,
+		})
 	}
-	return true
+
+	return comparable
+}
+
+func packageString(pr *ParseResult) string {
+	if pr.Package == nil {
+		return ""
+	}
+	return pr.Package.Literal()
 }

--- a/language/kotlin/resolver.go
+++ b/language/kotlin/resolver.go
@@ -20,15 +20,21 @@ import (
 
 var _ resolve.Resolver = (*kotlinLang)(nil)
 
+// ResolutionType represents the outcome of a dependency resolution attempt.
+type ResolutionType = int
+
 const (
+	// Resolution_Error indicates that an error occurred during dependency resolution (e.g. multiple matching targets).
 	Resolution_Error        = -1
+	// Resolution_None indicates that the import was resolved to the target itself (self-import), so no dependency is needed.
 	Resolution_None         = 0
+	// Resolution_NotFound indicates that the import could not be resolved.
 	Resolution_NotFound     = 1
+	// Resolution_Label indicates that the import was successfully resolved to a specific Bazel label.
 	Resolution_Label        = 2
+	// Resolution_NativeKotlin indicates that the import is a native/standard Kotlin or Java library import.
 	Resolution_NativeKotlin = 3
 )
-
-type ResolutionType = int
 
 func (*kotlinLang) Name() string {
 	return LanguageName
@@ -186,7 +192,18 @@ func (kt *kotlinLang) resolveImport(
 		if l, mavenError := (*mavenResolver).Resolve(jvm_import, cfg.ExcludedArtifacts(), cfg.MavenRepositoryName()); mavenError == nil {
 			return Resolution_Label, &l, nil
 		} else {
-			BazelLog.Debugf("Maven resolution failed: %v", mavenError)
+			dbgInfo := ""
+			if dbg, ok := (*mavenResolver).(interface{ DebugInfo() string }); ok {
+				dbgInfo = dbg.DebugInfo()
+			}
+			BazelLog.Debugf("Maven resolution error for import %q in source file %q. Using maven repo name %q, excluded artifacts (%v): error = %v; Maven debug info:\n%s",
+				impt.Imp,
+				impt.SourcePath,
+				cfg.MavenRepositoryName(),
+				cfg.ExcludedArtifacts(),
+				mavenError,
+				dbgInfo,
+			)
 		}
 	}
 

--- a/language/kotlin/tests/unknown_imports/expectedStderr.txt
+++ b/language/kotlin/tests/unknown_imports/expectedStderr.txt
@@ -1,1 +1,1 @@
-Resolution error Import "lib.not" from "lib.kt" is an unknown kotlin dependency
+Resolution error Import "lib.not.found" from "lib.kt" is an unknown kotlin dependency


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked PR Notice**: This PR is part of a stack. It depends on [PR #410](https://github.com/aspect-build/aspect-gazelle/pull/410) (which implements the Tree-Sitter parser upgrades). PR #410 must be merged first before the diff of this PR is meaningful.

### Problem

When resolving dependencies in Kotlin, consumers can import nested classes (e.g. `com.example.space.Moon.Phase`), import nested package-level members, or use wildcard/star imports. The standard Gazelle resolver maps imports by comparing package names or top-level identifiers directly against indexed rules. 

Without recursive parent package resolution, if a consumer imports a deeply nested child symbol like `com.example.space.Moon.Phase`, Gazelle's rule lookup fails because the index only exposes the top-level declaration `com.example.space.Moon` or the package prefix `com.example.space`. This results in missing dependencies or compile errors because Gazelle cannot map the nested import back to its defining library target.

Additionally, troubleshooting failed Maven resolutions is extremely difficult because Gazelle swallows internal resolver information (like active repository configurations, resolver search logs, or artifact exclusions), showing only a generic resolution failure.

---

### Motivating Example

Suppose `space/BUILD.bazel` defines a library target containing `Moon.kt` which declares a nested class `Phase` inside `Moon`:
```bazel
# space/BUILD.bazel
kt_jvm_library(
    name = "moon",
    srcs = ["Moon.kt"],
)
```

```kotlin
// space/Moon.kt
package com.example.space

class Moon {
    class Phase {
        val illumination = 1.0
    }
}
```

Now, consider a consumer file `hello/Astronomer.kt` that imports and references the nested class directly:
```kotlin
// hello/Astronomer.kt
package com.example.hello

import com.example.space.Moon.Phase

class Astronomer {
    fun observe(phase: Phase) {
        println("Observing moon phase with illumination: ${phase.illumination}")
    }
}
```

* **Under standard resolution (without recursive parent package lookup)**:
  1. Gazelle searches the rule index for a provider of the import `com.example.space.Moon.Phase`.
  2. Because the `space` package only indexes the top-level symbol `com.example.space.Moon` and the package prefix `com.example.space`, no direct match is found for `com.example.space.Moon.Phase`.
  3. Gazelle fails to resolve the import, leading to a missing dependency on `//space:moon` in `hello/BUILD.bazel`.
* **Under recursive parent package resolution (enabled by this PR)**:
  1. Gazelle first searches the rule index for `com.example.space.Moon.Phase` and finds no direct match.
  2. The resolver strips the rightmost component (`Phase`) to get the parent identifier: `com.example.space.Moon`.
  3. It queries the rule index for `com.example.space.Moon` and successfully matches the top-level symbol provided by `//space:moon`.
  4. The resolver mapping succeeds, and `//space:moon` is correctly added to the `deps` of the consumer target.

---

### Solution

This PR implements robust target resolution upgrades under `language/kotlin/`:
1. **Recursive Parent Package Resolution**: Upgrades the resolution flow in [resolver.go](file:///home/red/code/kotlin-gazelle/aspect-gazelle/language/kotlin/resolver.go) (`resolveImport`). If an import spec is not resolved initially, the resolver recursively climbs up the package hierarchy (`a.b.c` -> `a.b` -> `a`) using the parent traversal methods on `javaFullyQualifiedName` defined in [imports.go](file:///home/red/code/kotlin-gazelle/aspect-gazelle/language/kotlin/imports.go).
2. **Optimized Native Import Handling**: Refactors standard Kotlin and Java package classifications (e.g. `kotlin.io`, `kotlinx.*`, `java.*`, `javax.*`, `org.xml.sax.*`) in [kotlin.go](file:///home/red/code/kotlin-gazelle/aspect-gazelle/language/kotlin/kotlin.go) (`IsNativeImport`). These are matched instantly as `Resolution_NativeKotlin`, bypassing expensive and unnecessary Maven resolver queries.
3. **Verbose Maven Resolver Diagnostics**: 
   - Exposes detailed Maven resolver configuration state (like repository names, exclusions, and log details) upon resolution failure, printing them via `BazelLog.Debugf` to streamline debugging.
   - Extracts and traces internal `DebugInfo` from the Maven resolver in [configure.go](file:///home/red/code/kotlin-gazelle/aspect-gazelle/language/kotlin/configure.go) during initialization.
4. **Documentation Compliance**: Adds robust Go docstrings to all newly exposed public constants, types, and functions to align with Go style guidelines.

---

## Implementation Details & How it Works

* **Parent Traversal (`javaFullyQualifiedName`)**:
  - The `javaFullyQualifiedName` struct represents a dot-delimited list of identifiers.
  - The `Parent()` method strips the trailing part to return the parent package name (e.g., `a.b.c` -> `a.b`).
* **Recursive Resolution Loop**:
  - In `resolveImport`, if a query fails and the parent package is non-nil, Gazelle clones the import structure, updates the import target name to the parent package, and recursively invokes `resolveImport` until it resolves to a Bazel target, a Maven library, or runs out of parent package segments.
* **IsNativeImport Optimization**:
  - `IsNativeImport` checks the package prefix. If it matches `kotlin.`, `kotlinx.`, or standard JDK library prefixes from `rules_jvm`'s `IsStdlib`, it immediately resolves as a native import.

---

## Behavioral Changes & Directive Integration

1. **Does this PR result in any different behavior of the Gazelle plugin?**
   Yes. It resolves nested classes and member references to their correct Bazel targets, preventing resolution failures. It also provides clean debug logs explaining exactly why Maven resolution fails when resolving third-party coordinates.
2. **Does this PR respect the configuration directives added in [PR #409](https://github.com/aspect-build/aspect-gazelle/pull/409)?**
   Yes. The Maven resolver now respects the configuration directives by passing the user-configured maven repository name (`cfg.MavenRepositoryName()`) and excluded artifacts list (`cfg.ExcludedArtifacts()`) to the `Resolve` function call:
   ```go
   (*mavenResolver).Resolve(jvm_import, cfg.ExcludedArtifacts(), cfg.MavenRepositoryName())
   ```

---

## Testing Coverage

- **Unit Tests**:
  - Refactors `TestKotlinNative` in [kotlin_test.go](file:///home/red/code/kotlin-gazelle/aspect-gazelle/language/kotlin/kotlin_test.go) into a table-driven test suite checking a variety of native/standard Java and Kotlin package prefixes.
- **Integration Tests**:
  - The recursive package resolution behavior is verified end-to-end via `//tests:deep_import_test` where nested package structures are successfully mapped to their respective library targets.

---
Part of https://github.com/aspect-build/aspect-gazelle/issues/151
