### PR TITLE
fix(git): surface gitignore scan errors instead of silently truncating patterns

### DIFF
--- a/runner/pkg/git/gitignore.go
+++ b/runner/pkg/git/gitignore.go
@@ -26,7 +26,13 @@ func processGitignoreFile(rootDir, gitignorePath string, d any) (func(pathParts 
 		BazelLog.Tracef("Add gitignore file %s", gitignorePath)
 		defer ignoreReader.Close()
 
-		ignorePatterns = append(ignorePatterns, parseIgnore(path.Dir(gitignorePath), ignoreReader)...)
+		parsed, parseErr := parseIgnore(path.Dir(gitignorePath), ignoreReader)
+		if parseErr != nil {
+			msg := fmt.Sprintf("Failed to read %s: %v", gitignorePath, parseErr)
+			BazelLog.Error(msg)
+			fmt.Printf("%s\n", msg)
+		}
+		ignorePatterns = append(ignorePatterns, parsed...)
 	} else {
 		msg := fmt.Sprintf("Failed to open %s: %v", gitignorePath, ignoreErr)
 		BazelLog.Error(msg)
@@ -48,7 +54,7 @@ func createMatcherFunc(ignorePatterns []gitignore.Pattern) isGitIgnored {
 	return gitignore.NewMatcher(ignorePatterns).Match
 }
 
-func parseIgnore(rel string, ignoreReader io.Reader) []gitignore.Pattern {
+func parseIgnore(rel string, ignoreReader io.Reader) ([]gitignore.Pattern, error) {
 	var domain []string
 	if rel != "" && rel != "." {
 		domain = strings.Split(path.Clean(rel), "/")
@@ -66,7 +72,7 @@ func parseIgnore(rel string, ignoreReader io.Reader) []gitignore.Pattern {
 		matcherPatterns = append(matcherPatterns, parsePattern(p, domain))
 	}
 
-	return matcherPatterns
+	return matcherPatterns, reader.Err()
 }
 
 func parsePattern(p string, domain []string) gitignore.Pattern {

--- a/runner/pkg/git/gitignore_test.go
+++ b/runner/pkg/git/gitignore_test.go
@@ -185,11 +185,28 @@ func TestGitIgnore(t *testing.T) {
 	t.Run("escaped trailing whitespace", func(t *testing.T) {
 		// Bypass addIgnoreFileContent helper (which TrimSpaces lines)
 		// to test that parseIgnore preserves escaped trailing spaces.
-		patterns := parseIgnore("", strings.NewReader("foo\\ \n"))
+		patterns, err := parseIgnore("", strings.NewReader("foo\\ \n"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		m := createMatcherFunc(patterns)
 
 		shouldMatch("escaped trailing space", m, "foo ")
 		shouldNotMatch("without trailing space", m, "foo")
+	})
+
+	t.Run("scan error is surfaced", func(t *testing.T) {
+		// A line longer than bufio.Scanner's max token size (64 KiB) makes
+		// Scan() stop early and Err() report bufio.ErrTooLong. The patterns
+		// parsed before it must not be silently treated as the complete set.
+		content := "node_modules/\n" + strings.Repeat("a", 70000) + "\n"
+		patterns, err := parseIgnore("", strings.NewReader(content))
+		if err == nil {
+			t.Fatal("expected a scan error for an over-long line, got nil")
+		}
+		if len(patterns) != 1 {
+			t.Fatalf("expected the 1 pattern parsed before the error, got %d", len(patterns))
+		}
 	})
 
 	t.Run("dir specific matches", func(t *testing.T) {
@@ -266,7 +283,7 @@ func addIgnoreFileContent(parentPatterns []gitignore.Pattern, rel, ignoreContent
 		}
 	}
 
-	patterns := parseIgnore(rel, strings.NewReader(strings.Join(ignoreLines, "\n")))
+	patterns, _ := parseIgnore(rel, strings.NewReader(strings.Join(ignoreLines, "\n")))
 	patterns = append(parentPatterns, patterns...)
 
 	return createMatcherFunc(patterns), patterns


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
