### PR TITLE
fix(orion): stringify non-string YAML mapping keys instead of panicking

### DIFF
--- a/language/orion/queries/BUILD.bazel
+++ b/language/orion/queries/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "queries",
@@ -30,4 +30,11 @@ go_library(
         "@com_github_itchyny_gojq//:gojq",
         "@com_github_mikefarah_yq_v4//pkg/yqlib",
     ],
+)
+
+go_test(
+    name = "queries_test",
+    srcs = ["yq_test.go"],
+    embed = [":queries"],
+    deps = ["//plugin"],
 )

--- a/language/orion/queries/yq.go
+++ b/language/orion/queries/yq.go
@@ -2,6 +2,7 @@ package queries
 
 import (
 	"bytes"
+	"fmt"
 
 	BazelLog "github.com/aspect-build/aspect-gazelle/common/logger"
 	"github.com/aspect-build/aspect-gazelle/language/orion/plugin"
@@ -53,7 +54,11 @@ func convertYqNodeToValue(node *yqlib.CandidateNode) interface{} {
 		for i := 0; i < len(node.Content); i += 2 {
 			key := convertYqNodeToValue(node.Content[i])
 			value := convertYqNodeToValue(node.Content[i+1])
-			m[key.(string)] = value
+			keyStr, ok := key.(string)
+			if !ok {
+				keyStr = fmt.Sprint(key)
+			}
+			m[keyStr] = value
 		}
 		return m
 	case yqlib.SequenceNode:

--- a/language/orion/queries/yq_test.go
+++ b/language/orion/queries/yq_test.go
@@ -1,0 +1,33 @@
+package queries
+
+import (
+	"testing"
+
+	"github.com/aspect-build/aspect-gazelle/language/orion/plugin"
+)
+
+// A YAML mapping key is not required to be a string: integers, booleans, and
+// even nested mappings/sequences are valid keys. Such a document must not
+// crash the gazelle run.
+func TestYamlNonStringMappingKey(t *testing.T) {
+	tests := map[string]string{
+		"integer key": "123: foo\n",
+		"boolean key": "true: foo\n",
+		"float key":   "1.5: foo\n",
+	}
+
+	for name, src := range tests {
+		t.Run(name, func(t *testing.T) {
+			queries := plugin.NamedQueries{"q": &plugin.YamlQuery{Query: "."}}
+
+			// Before the fix this panicked on an unchecked key.(string).
+			results, err := runYamlQueries([]byte(src), queries)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if results["q"] == nil {
+				t.Fatalf("expected a result for query %q, got nil", "q")
+			}
+		})
+	}
+}

--- a/language/orion/tests/starzelle/query-yaml-nonstring-key/BUILD.out
+++ b/language/orion/tests/starzelle/query-yaml-nonstring-key/BUILD.out
@@ -1,0 +1,10 @@
+load("@deps-test//my:rules.bzl", "x_lib")
+
+x_lib(
+    name = "data_lib",
+    srcs = ["data.yaml"],
+    config_keys = [
+        "123",
+        "true",
+    ],
+)

--- a/language/orion/tests/starzelle/query-yaml-nonstring-key/WORKSPACE
+++ b/language/orion/tests/starzelle/query-yaml-nonstring-key/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "query_yaml_nonstring_key")

--- a/language/orion/tests/starzelle/query-yaml-nonstring-key/data.yaml
+++ b/language/orion/tests/starzelle/query-yaml-nonstring-key/data.yaml
@@ -1,0 +1,3 @@
+config:
+  123: foo
+  true: bar

--- a/language/orion/tests/starzelle/query-yaml-nonstring-key/nonstring.axl
+++ b/language/orion/tests/starzelle/query-yaml-nonstring-key/nonstring.axl
@@ -1,0 +1,37 @@
+aspect.gazelle_rule_kind("x_lib", {
+    "From": "@deps-test//my:rules.bzl",
+    "MergeableAttrs": ["srcs"],
+})
+
+def prepare(_):
+    return aspect.PrepareResult(
+        sources = aspect.SourceExtensions(".yaml"),
+        queries = {
+            # Returns the nested mapping, which has a non-string (integer) key.
+            # Converting it must not crash the gazelle run.
+            "cfg": aspect.YamlQuery(
+                filter = "*.yaml",
+                query = ".config",
+            ),
+        },
+    )
+
+def declare(ctx):
+    for file in ctx.sources:
+        # The query result is a list with the matched mapping. Its keys are the
+        # (originally non-string) YAML keys, stringified by the conversion.
+        config = file.query_results["cfg"][0]
+        ctx.targets.add(
+            name = file.path[:file.path.rindex(".")] + "_lib",
+            kind = "x_lib",
+            attrs = {
+                "srcs": [file.path],
+                "config_keys": sorted(config.keys()),
+            },
+        )
+
+aspect.orion_extension(
+    id = "yaml-nonstring-key-test",
+    prepare = prepare,
+    declare = declare,
+)


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
