### PR TITLE
fix: handle non-standard ts_project(gen_connect_query_service_mapping) types

### DIFF
--- a/language/js/resolve.go
+++ b/language/js/resolve.go
@@ -187,13 +187,23 @@ func (ts *typeScriptLang) protoLibraryImports(r *rule.Rule, f *rule.File) []reso
 		// Query services: https://github.com/aspect-build/rules_ts/blob/v3.4.0/ts/private/ts_proto_library.bzl#L74-L78
 		if ruleUtils.AttrBool(r, "gen_connect_query") {
 			for _, p := range ruleUtils.AttrMap(r, "gen_connect_query_service_mapping") {
-				proto := p.Key.(*build.StringExpr).Value
-				protoName := strings.TrimSuffix(proto, ".proto")
+				protoKey, isString := p.Key.(*build.StringExpr)
+				if !isString {
+					BazelLog.Errorf("Expected ts_proto_library.gen_connect_query_service_mapping key to be a string, got %v", p.Key)
+					continue
+				}
+				protoName := strings.TrimSuffix(protoKey.Value, ".proto")
 
 				if services, isServicesArray := p.Value.(*build.ListExpr); isServicesArray {
 					for _, service := range services.List {
+						serviceStr, isString := service.(*build.StringExpr)
+						if !isString {
+							BazelLog.Errorf("Expected ts_proto_library.gen_connect_query_service_mapping service to be a string, got %v", service)
+							continue
+						}
+
 						// Service filename: https://github.com/aspect-build/rules_ts/blob/v3.4.0/ts/private/ts_proto_library.bzl#L78C54-L78C105
-						serviceFile := fmt.Sprintf("%s-%s_connectquery", protoName, service.(*build.StringExpr).Value)
+						serviceFile := fmt.Sprintf("%s-%s_connectquery", protoName, serviceStr.Value)
 
 						dtsOutputs = append(dtsOutputs, path.Join(f.Pkg, serviceFile))
 					}

--- a/language/js/tests/ts_proto_library_bad_mapping/BUILD.in
+++ b/language/js/tests/ts_proto_library_bad_mapping/BUILD.in
@@ -1,0 +1,22 @@
+load("@aspect_rules_ts//ts:proto.bzl", "ts_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "lib_proto",
+    srcs = ["lib.proto"],
+    visibility = ["//visibility:public"],
+)
+
+# The gen_connect_query_service_mapping contains a non-string-literal key (a
+# bare identifier) and a non-string-literal service element. Both are legal
+# Starlark; gazelle must skip them rather than panic while indexing this rule.
+ts_proto_library(
+    name = "lib_proto_ts",
+    gen_connect_es = True,
+    gen_connect_query = True,
+    gen_connect_query_service_mapping = {
+        lib_proto: ["MyService"],
+        "lib.proto": [MyService],
+    },
+    proto = ":lib_proto",
+)

--- a/language/js/tests/ts_proto_library_bad_mapping/BUILD.out
+++ b/language/js/tests/ts_proto_library_bad_mapping/BUILD.out
@@ -1,0 +1,30 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@aspect_rules_ts//ts:proto.bzl", "ts_proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+
+proto_library(
+    name = "lib_proto",
+    srcs = ["lib.proto"],
+    visibility = ["//visibility:public"],
+)
+
+# The gen_connect_query_service_mapping contains a non-string-literal key (a
+# bare identifier) and a non-string-literal service element. Both are legal
+# Starlark; gazelle must skip them rather than panic while indexing this rule.
+ts_proto_library(
+    name = "lib_proto_ts",
+    gen_connect_es = True,
+    gen_connect_query = True,
+    gen_connect_query_service_mapping = {
+        lib_proto: ["MyService"],
+        "lib.proto": [MyService],
+    },
+    proto = ":lib_proto",
+    proto_srcs = ["lib.proto"],
+)
+
+ts_project(
+    name = "ts_proto_library_ignore",
+    srcs = ["main.ts"],
+    deps = [":lib_proto_ts"],
+)

--- a/language/js/tests/ts_proto_library_bad_mapping/MODULE.bazel
+++ b/language/js/tests/ts_proto_library_bad_mapping/MODULE.bazel
@@ -1,0 +1,1 @@
+bazel_dep(name = "protobuf")

--- a/language/js/tests/ts_proto_library_bad_mapping/WORKSPACE
+++ b/language/js/tests/ts_proto_library_bad_mapping/WORKSPACE
@@ -1,0 +1,2 @@
+# This is a Bazel workspace for the Gazelle test data.
+workspace(name = "ts_proto_library_ignore")

--- a/language/js/tests/ts_proto_library_bad_mapping/lib.proto
+++ b/language/js/tests/ts_proto_library_bad_mapping/lib.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+message SayRequest {
+    string sentence = 1;
+}
+
+service MyService {
+}

--- a/language/js/tests/ts_proto_library_bad_mapping/main.ts
+++ b/language/js/tests/ts_proto_library_bad_mapping/main.ts
@@ -1,0 +1,1 @@
+import './lib_pb'


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
