### PR TITLE
chore: bump rules_python_gazelle_plugin to 2.1.0

### DIFF
--- a/runner/MODULE.bazel
+++ b/runner/MODULE.bazel
@@ -34,7 +34,7 @@ bazel_dep(name = "gazelle", version = "0.51.3")  # must match go.mod
 
 # Gazelle languages via bzlmod
 bazel_dep(name = "rules_buf", version = "0.5.4")
-bazel_dep(name = "rules_python_gazelle_plugin", version = "2.0.2")  # must match go.mod
+bazel_dep(name = "rules_python_gazelle_plugin", version = "2.1.0")  # must match go.mod
 bazel_dep(name = "gazelle_cc", version = "0.6.0")  # must match go.mod
 
 # Override the gazelle used locally to apply aspect patches

--- a/runner/go.mod
+++ b/runner/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aspect-build/aspect-gazelle/language/js v0.0.0-20260617211333-3d8b9bffa90f
 	github.com/aspect-build/aspect-gazelle/language/kotlin v0.0.0-20260617211333-3d8b9bffa90f
 	github.com/aspect-build/aspect-gazelle/language/orion v0.0.0-20260617211333-3d8b9bffa90f
-	github.com/bazel-contrib/rules_python/gazelle v0.0.0-20260520000513-6aad8828e826
+	github.com/bazel-contrib/rules_python/gazelle v0.0.0-20260618025646-5c32fa99b8b0
 	github.com/bazelbuild/bazel-gazelle v0.51.3 // NOTE: keep in sync with MODULE.bazel
 	github.com/bazelbuild/buildtools v0.0.0-20260528135316-84fa6c32aee6
 	github.com/bufbuild/rules_buf v0.5.4 // NOTE: keep in sync with MODULE.bazel

--- a/runner/go.sum
+++ b/runner/go.sum
@@ -28,8 +28,8 @@ github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2 h1:lSINS7DK4xjm0Z4CBd7onO63uI
 github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2/go.mod h1:B76PjnaM2KyUG8ypV/ePHHDmGbyUNZ2PCEdEQIJISQM=
 github.com/bazel-contrib/rules_jvm v0.33.0 h1:hdGoYvvHNdC23U4+V7MysWSXUUV84XsOcdk1hw6wWC8=
 github.com/bazel-contrib/rules_jvm v0.33.0/go.mod h1:HxRDtmRlh/ErR+2QlVwYs4BcIrB248HeheKi5uyKeN4=
-github.com/bazel-contrib/rules_python/gazelle v0.0.0-20260520000513-6aad8828e826 h1:TbBiToSVItW5W0Jv1uKklxbFrWlpp/cocXk3t7j0X34=
-github.com/bazel-contrib/rules_python/gazelle v0.0.0-20260520000513-6aad8828e826/go.mod h1:84dcq5fZ/hiQGnpjzH57+Xm7T6uwpPty1KPB7qzHDO0=
+github.com/bazel-contrib/rules_python/gazelle v0.0.0-20260618025646-5c32fa99b8b0 h1:gm77ulBbMBP+d/9LZJEhggwmm+HneRq2Y2AkWU6mxQM=
+github.com/bazel-contrib/rules_python/gazelle v0.0.0-20260618025646-5c32fa99b8b0/go.mod h1:BJbb/9MDQTFr8wlzDF5GGVJPdmBGBcSpC2U0BruJy6Q=
 github.com/bazelbuild/bazel-gazelle v0.51.3 h1:WtLCDPJTj06AWZizuN0SpkX8njjH1meOFgYbia6mD64=
 github.com/bazelbuild/bazel-gazelle v0.51.3/go.mod h1:AeYjUGaxXcMZ51CYHBT1YK3Qxb2yrJl77A8g7GF6d+g=
 github.com/bazelbuild/buildtools v0.0.0-20260528135316-84fa6c32aee6 h1:qoTpOHw6TAC4AtKC/O/Bx2QXn2c8OnzwTOD1nBzLynk=


### PR DESCRIPTION
Bump rules_python_gazelle_plugin to 2.1.0: https://github.com/bazel-contrib/rules_python/releases/tag/2.1.0 (commit 5c32fa99b8b0ab15364d2f5d6ba65b8336e9ac62)

- upgrade MODULE.bazel file
- update the go files via
```
go get github.com/bazel-contrib/rules_python/gazelle@5c32fa99b8b0ab15364d2f5d6ba65b8336e9ac62
go mod tidy
```

### Changes are visible to end-users: no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan
CI will tell

