### PR TITLE
fix: do not declare ibp signal socket-ready until full handshake complete

### DIFF
--- a/runner/pkg/ibp/protocol.go
+++ b/runner/pkg/ibp/protocol.go
@@ -54,7 +54,7 @@ const (
 const PROTOCOL_SOCKET_ENV = "ABAZEL_WATCH_SOCKET_FILE"
 
 type IncrementalBazel interface {
-	// Messaging to the client
+	// Messaging to the client. Must not be called until IsReady().
 	Init(ctx context.Context, scope WatchScope, sources SourceInfoMap) error
 	Cycle(ctx context.Context, scope WatchScope, changes SourceInfoMap) error
 	CycleReset(ctx context.Context) error
@@ -63,9 +63,15 @@ type IncrementalBazel interface {
 	// Server + Connection to client
 	Serve(ctx context.Context) error
 	Close() error
-	HasConnection() bool
 
-	WaitForConnection() <-chan ProtocolVersion
+	// If the handshake with a connected client has completed and messaging may begin.
+	IsReady() bool
+
+	// A channel closed once the handshake completes; see NegotiatedVersion for the result.
+	WaitForReady() <-chan struct{}
+
+	// The protocol version negotiated with the client, or -1 until IsReady.
+	NegotiatedVersion() ProtocolVersion
 
 	// If this connection is watching the given scope, e.g. sources or runfiles.
 	WatchingScope(s WatchScope) bool
@@ -152,10 +158,10 @@ type aspectBazelProtocol struct {
 	socket     aspectBazelSocket
 	socketPath string
 
-	// connectedCh is used to signal when a connection has been established and the protocol version that was negotiated.
-	connectedCh chan ProtocolVersion
+	// connectedCh is closed once the handshake completes, making connectedVersion+caps safe to read.
+	connectedCh chan struct{}
 
-	// Available once connectedCh emits a version
+	// Available once connectedCh is closed
 	connectedVersion ProtocolVersion
 	caps             map[WatchCapability]any
 
@@ -171,18 +177,25 @@ func NewServer() IncrementalBazel {
 		socketPath: socketPath,
 		socket:     socket.NewJsonServer[any, map[string]any](),
 
-		connectedCh:      make(chan ProtocolVersion, 1),
+		connectedCh:      make(chan struct{}),
 		connectedVersion: -1, // Invalid version to indicate not connected
 	}
 }
 
-func (p *aspectBazelProtocol) WaitForConnection() <-chan ProtocolVersion {
+func (p *aspectBazelProtocol) WaitForReady() <-chan struct{} {
 	return p.connectedCh
 }
 
+func (p *aspectBazelProtocol) NegotiatedVersion() ProtocolVersion {
+	if !p.IsReady() {
+		return -1
+	}
+	return p.connectedVersion
+}
+
 func (p *aspectBazelProtocol) WatchingScope(s WatchScope) bool {
-	// No caps or no scope cap means default to runfiles only
-	if p.caps == nil || p.caps[WatchCapability_WatchScope] == nil {
+	// Caps are not readable until the handshake completes; no caps or no scope cap means default to runfiles only
+	if !p.IsReady() || p.caps == nil || p.caps[WatchCapability_WatchScope] == nil {
 		return s == WatchScope_Runfiles
 	}
 
@@ -246,8 +259,21 @@ func (p *aspectBazelProtocol) Serve(ctx context.Context) error {
 	return nil
 }
 
-func (p *aspectBazelProtocol) HasConnection() bool {
-	return p.socket != nil && p.socket.HasConnection()
+func (p *aspectBazelProtocol) IsReady() bool {
+	select {
+	case <-p.connectedCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// errNotReady guards messaging methods from racing the handshake and corrupting the protocol.
+func (p *aspectBazelProtocol) errNotReady(msg string) error {
+	if p.IsReady() {
+		return nil
+	}
+	return fmt.Errorf("cannot send %s: watch protocol handshake not complete, see IsReady()", msg)
 }
 
 func (p *aspectBazelProtocol) acceptNegotiation(ctx context.Context) error {
@@ -289,7 +315,7 @@ func (p *aspectBazelProtocol) acceptNegotiation(ctx context.Context) error {
 	}
 
 	p.connectedVersion = version
-	p.connectedCh <- version
+	close(p.connectedCh)
 
 	return nil
 }
@@ -337,6 +363,10 @@ func (p *aspectBazelProtocol) Init(ctx context.Context, scope WatchScope, source
 }
 
 func (p *aspectBazelProtocol) Cycle(ctx context.Context, scope WatchScope, changes SourceInfoMap) error {
+	if err := p.errNotReady("CYCLE"); err != nil {
+		return err
+	}
+
 	cycle_id := int(p.cycle_id.Add(1))
 
 	fmt.Printf("%s Sending cycle #%v (%v changes) to %s\n", color.GreenString("INFO:"), cycle_id, len(changes), p.socketPath)
@@ -363,6 +393,10 @@ func (p *aspectBazelProtocol) Cycle(ctx context.Context, scope WatchScope, chang
 }
 
 func (p *aspectBazelProtocol) CycleReset(ctx context.Context) error {
+	if err := p.errNotReady("CYCLE_RESET"); err != nil {
+		return err
+	}
+
 	if !p.connectedVersion.HasResetMessage() {
 		return fmt.Errorf("CYCLE_RESET requires protocol >= v%d, negotiated v%d", VERSION_2, p.connectedVersion)
 	}
@@ -421,6 +455,10 @@ func (p *aspectBazelProtocol) awaitCycleResponse(cycle_id int) error {
 }
 
 func (p *aspectBazelProtocol) Exit(ctx context.Context, err error) error {
+	if notReadyErr := p.errNotReady("EXIT"); notReadyErr != nil {
+		return notReadyErr
+	}
+
 	d := ""
 	if err != nil {
 		d = err.Error()

--- a/runner/pkg/ibp/protocol_test.go
+++ b/runner/pkg/ibp/protocol_test.go
@@ -44,8 +44,10 @@ func (s *fakeServerSocket) Accept() error {
 	return nil
 }
 
-func (s *fakeServerSocket) HasConnection() bool {
-	return true
+// handshakeComplete marks the protocol ready as if acceptNegotiation finished.
+func handshakeComplete(p *aspectBazelProtocol) *aspectBazelProtocol {
+	close(p.connectedCh)
+	return p
 }
 
 func TestReadCapsRequestMap_DefaultsToRunfilesWhenNil(t *testing.T) {
@@ -95,7 +97,7 @@ func TestReadCapsRequestMap_RejectsInvalidScope(t *testing.T) {
 }
 
 func TestWatchingScope_DefaultAndConfigured(t *testing.T) {
-	p := &aspectBazelProtocol{}
+	p := &aspectBazelProtocol{connectedCh: make(chan struct{})}
 	if !p.WatchingScope(WatchScope_Runfiles) {
 		t.Fatal("expected default to watch runfiles")
 	}
@@ -106,6 +108,16 @@ func TestWatchingScope_DefaultAndConfigured(t *testing.T) {
 	p.caps = map[WatchCapability]any{
 		WatchCapability_WatchScope: []WatchScope{WatchScope_Sources},
 	}
+
+	// Caps must not be observable until the handshake completes.
+	if p.WatchingScope(WatchScope_Sources) {
+		t.Fatal("did not expect sources scope to be watched before the handshake completes")
+	}
+	if !p.WatchingScope(WatchScope_Runfiles) {
+		t.Fatal("expected the runfiles default before the handshake completes")
+	}
+
+	handshakeComplete(p)
 	if !p.WatchingScope(WatchScope_Sources) {
 		t.Fatal("expected sources scope to be watched")
 	}
@@ -152,12 +164,21 @@ func TestAcceptNegotiation_LegacyVersionSkipsCapsHandshake(t *testing.T) {
 	}
 	p := &aspectBazelProtocol{
 		socket:           socket,
-		connectedCh:      make(chan ProtocolVersion, 1),
+		connectedCh:      make(chan struct{}),
 		connectedVersion: -1,
 	}
 
+	if p.IsReady() {
+		t.Fatal("expected IsReady to be false before the handshake")
+	}
+	if v := p.NegotiatedVersion(); v != -1 {
+		t.Fatalf("expected no negotiated version before the handshake, got %d", v)
+	}
 	if err := p.acceptNegotiation(context.Background()); err != nil {
 		t.Fatalf("acceptNegotiation returned error: %v", err)
+	}
+	if !p.IsReady() {
+		t.Fatal("expected IsReady to be true after the handshake")
 	}
 	if socket.acceptCalls != 1 {
 		t.Fatalf("expected one accept call, got %d", socket.acceptCalls)
@@ -183,12 +204,12 @@ func TestAcceptNegotiation_LegacyVersionSkipsCapsHandshake(t *testing.T) {
 	}
 
 	select {
-	case version := <-p.connectedCh:
-		if version != LEGACY_VERSION_0 {
-			t.Fatalf("expected legacy version on connectedCh, got %d", version)
-		}
+	case <-p.WaitForReady():
 	default:
-		t.Fatal("expected connectedCh to receive negotiated legacy version")
+		t.Fatal("expected WaitForReady channel to be closed after the handshake")
+	}
+	if v := p.NegotiatedVersion(); v != LEGACY_VERSION_0 {
+		t.Fatalf("expected negotiated legacy version, got %d", v)
 	}
 }
 
@@ -201,11 +222,12 @@ func TestCycle_LegacyVersionClearsScopeForCompatibility(t *testing.T) {
 			},
 		},
 	}
-	p := &aspectBazelProtocol{
+	p := handshakeComplete(&aspectBazelProtocol{
 		socket:           socket,
 		socketPath:       "test.sock",
+		connectedCh:      make(chan struct{}),
 		connectedVersion: LEGACY_VERSION_0,
-	}
+	})
 
 	if err := p.Cycle(context.Background(), WatchScope_Sources, SourceInfoMap{}); err != nil {
 		t.Fatalf("Cycle returned error: %v", err)
@@ -232,11 +254,12 @@ func TestCycle_V1KeepsScope(t *testing.T) {
 			},
 		},
 	}
-	p := &aspectBazelProtocol{
+	p := handshakeComplete(&aspectBazelProtocol{
 		socket:           socket,
 		socketPath:       "test.sock",
+		connectedCh:      make(chan struct{}),
 		connectedVersion: VERSION_1,
-	}
+	})
 
 	if err := p.Cycle(context.Background(), WatchScope_Sources, SourceInfoMap{}); err != nil {
 		t.Fatalf("Cycle returned error: %v", err)
@@ -263,11 +286,12 @@ func TestCycleReset_V2SendsCycleResetMessage(t *testing.T) {
 			},
 		},
 	}
-	p := &aspectBazelProtocol{
+	p := handshakeComplete(&aspectBazelProtocol{
 		socket:           socket,
 		socketPath:       "test.sock",
+		connectedCh:      make(chan struct{}),
 		connectedVersion: VERSION_2,
-	}
+	})
 
 	if err := p.CycleReset(context.Background()); err != nil {
 		t.Fatalf("CycleReset returned error: %v", err)
@@ -290,11 +314,12 @@ func TestCycleReset_V2SendsCycleResetMessage(t *testing.T) {
 
 func TestCycleReset_RejectsOnPreV2Connection(t *testing.T) {
 	for _, version := range []ProtocolVersion{LEGACY_VERSION_0, VERSION_1} {
-		p := &aspectBazelProtocol{
+		p := handshakeComplete(&aspectBazelProtocol{
 			socket:           &fakeServerSocket{},
 			socketPath:       "test.sock",
+			connectedCh:      make(chan struct{}),
 			connectedVersion: version,
-		}
+		})
 		if err := p.CycleReset(context.Background()); err == nil {
 			t.Fatalf("expected CycleReset to fail on v%d, got nil error", version)
 		}
@@ -323,6 +348,48 @@ func TestCycleResetMessage_SerializesWithoutSourcesOrScope(t *testing.T) {
 	}
 }
 
+func TestMessaging_RejectedUntilHandshakeCompletes(t *testing.T) {
+	// Messaging on an accepted connection must be rejected until the handshake completes.
+	socket := &fakeServerSocket{}
+	p := &aspectBazelProtocol{
+		socket:           socket,
+		socketPath:       "test.sock",
+		connectedCh:      make(chan struct{}),
+		connectedVersion: -1,
+	}
+	ctx := context.Background()
+
+	if err := p.Init(ctx, WatchScope_Runfiles, SourceInfoMap{}); err == nil {
+		t.Fatal("expected Init to fail before handshake completes")
+	}
+	if err := p.Cycle(ctx, WatchScope_Runfiles, SourceInfoMap{}); err == nil {
+		t.Fatal("expected Cycle to fail before handshake completes")
+	}
+	if err := p.CycleReset(ctx); err == nil {
+		t.Fatal("expected CycleReset to fail before handshake completes")
+	}
+	if err := p.Exit(ctx, nil); err == nil {
+		t.Fatal("expected Exit to fail before handshake completes")
+	}
+	if len(socket.sent) != 0 {
+		t.Fatalf("expected nothing sent on the socket before handshake completes, got %#v", socket.sent)
+	}
+
+	p.connectedVersion = VERSION_2
+	handshakeComplete(p)
+
+	socket.recvQueue = []map[string]any{{"kind": "CYCLE_COMPLETED", "cycle_id": float64(1)}}
+	if err := p.Cycle(ctx, WatchScope_Runfiles, SourceInfoMap{}); err != nil {
+		t.Fatalf("Cycle after handshake returned error: %v", err)
+	}
+	if err := p.Exit(ctx, nil); err != nil {
+		t.Fatalf("Exit after handshake returned error: %v", err)
+	}
+	if len(socket.sent) != 2 {
+		t.Fatalf("expected CYCLE and EXIT sends after handshake, got %#v", socket.sent)
+	}
+}
+
 func TestInit_SendsBaselineCycle(t *testing.T) {
 	socket := &fakeServerSocket{
 		recvQueue: []map[string]any{
@@ -332,11 +399,12 @@ func TestInit_SendsBaselineCycle(t *testing.T) {
 			},
 		},
 	}
-	p := &aspectBazelProtocol{
+	p := handshakeComplete(&aspectBazelProtocol{
 		socket:           socket,
 		socketPath:       "test.sock",
+		connectedCh:      make(chan struct{}),
 		connectedVersion: VERSION_1,
-	}
+	})
 
 	if err := p.Init(context.Background(), WatchScope_Sources, SourceInfoMap{"a.txt": nil}); err != nil {
 		t.Fatalf("Init returned error: %v", err)

--- a/runner/pkg/socket/json.go
+++ b/runner/pkg/socket/json.go
@@ -84,10 +84,6 @@ func (sock *jsonClientSocket[S, R]) connect(socketPath string) error {
 	return nil
 }
 
-func (sock *jsonServerSocket[S, R]) HasConnection() bool {
-	return sock.conn != nil
-}
-
 func (sock *jsonServerSocket[S, R]) Close() error {
 	var err error
 	if sock.serv != nil {

--- a/runner/pkg/socket/socket.go
+++ b/runner/pkg/socket/socket.go
@@ -10,5 +10,4 @@ type Server[S, R any] interface {
 	Socket[S, R]
 	Serve(path string) error
 	Accept() error
-	HasConnection() bool
 }


### PR DESCRIPTION
Ref https://github.com/aspect-build/rules_js/issues/2894

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

Breaking changes to the Increment-Build-Protocol Go API.

### Test plan

- Covered by existing test cases
- New test cases added
