### PR TITLE
fix(orion): resolve cross-language imports from registered symbols

### DIFF
--- a/language/orion/resolver.go
+++ b/language/orion/resolver.go
@@ -400,7 +400,27 @@ func (ts *GazelleHost) CrossResolve(c *config.Config, ix *resolve.RuleIndex, imp
 
 	// Search for results within this gazelle language, without further invoking CrossResolve
 	// via FindRulesByImportWithConfig.
-	return ix.FindRulesByImport(imp, GazelleLanguageName)
+	results := ix.FindRulesByImport(imp, GazelleLanguageName)
+	labels := make(map[label.Label]struct{}, len(results))
+	for _, result := range results {
+		labels[result.Label] = struct{}{}
+	}
+
+	for _, symbol := range ts.database.LookupSymbols(imp.Imp) {
+		if symbol.Provider != imp.Lang {
+			continue
+		}
+
+		l := symbolLabel(symbol)
+		if _, found := labels[l]; found {
+			continue
+		}
+
+		labels[l] = struct{}{}
+		results = append(results, resolve.FindResult{Label: l})
+	}
+
+	return results
 }
 
 // targetListFromResults returns a string with the human-readable list of

--- a/runner/tests/crossresolve-go-imports-orion-db/BUILD.in
+++ b/runner/tests/crossresolve-go-imports-orion-db/BUILD.in
@@ -1,0 +1,7 @@
+filegroup(
+    name = "provider",
+)
+
+filegroup(
+    name = "wrong_provider",
+)

--- a/runner/tests/crossresolve-go-imports-orion-db/BUILD.out
+++ b/runner/tests/crossresolve-go-imports-orion-db/BUILD.out
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+filegroup(
+    name = "provider",
+)
+
+filegroup(
+    name = "wrong_provider",
+)
+
+go_library(
+    name = "consumer",
+    srcs = ["consumer.go"],
+    importpath = "example.com/consumer",
+    visibility = ["//visibility:public"],
+    deps = [":provider"],
+)

--- a/runner/tests/crossresolve-go-imports-orion-db/WORKSPACE
+++ b/runner/tests/crossresolve-go-imports-orion-db/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "go-imports-orion-db")

--- a/runner/tests/crossresolve-go-imports-orion-db/consumer.go
+++ b/runner/tests/crossresolve-go-imports-orion-db/consumer.go
@@ -1,0 +1,3 @@
+package consumer
+
+import _ "example.com/provider"

--- a/runner/tests/crossresolve-go-imports-orion-db/go.mod
+++ b/runner/tests/crossresolve-go-imports-orion-db/go.mod
@@ -1,0 +1,3 @@
+module example.com/consumer
+
+go 1.26.4

--- a/runner/tests/crossresolve-go-imports-orion-db/provider.axl
+++ b/runner/tests/crossresolve-go-imports-orion-db/provider.axl
@@ -1,0 +1,21 @@
+def declare(ctx):
+    ctx.add_symbol(
+        id = "example.com/provider",
+        provider_type = "proto",
+        label = aspect.Label(name = "wrong_provider"),
+    )
+    ctx.add_symbol(
+        id = "example.com/provider",
+        provider_type = "go",
+        label = aspect.Label(name = "provider"),
+    )
+    ctx.add_symbol(
+        id = "example.com/provider",
+        provider_type = "go",
+        label = aspect.Label(name = "provider"),
+    )
+
+aspect.orion_extension(
+    id = "go-provider",
+    declare = declare,
+)


### PR DESCRIPTION
_AI Disclosure: This PR was drafted with AI assistance_

## Problem

`ctx.add_symbol` records an import, provider type, and Bazel label in Orion's symbol database. Orion consults this database when it resolves `aspect.Import` values in Orion-generated rules.

Rules generated by other Gazelle languages resolve imports through Gazelle's rule index. When the index has no direct match, Gazelle asks registered cross-resolvers, including `GazelleHost.CrossResolve`. Before this change, Orion's `CrossResolve` searched Orion's rule-index entries but did not consult symbols registered through `ctx.add_symbol`.

This matters when the real target is not represented by an importable rule in the parsed BUILD file. For example, a macro may create `//generated:provider`:

```starlark
# generated/BUILD.bazel
provider_bundle(name = "provider")
```

Gazelle sees the macro invocation, not the target created when Bazel expands it. An Orion extension may know that the macro creates `//generated:provider` and register the exact Go import-to-label mapping. A Go consumer still cannot obtain that mapping through `CrossResolve`:

```go
import _ "example.com/provider"
```

With no cross-resolution match, Go continues with its normal unresolved-import behavior instead of selecting `//generated:provider`.

### Existing workaround

One workaround is to register a synthetic Gazelle rule kind named `provider_symbol`. Its Starlark implementation is a no-op:

```starlark
def provider_symbol(**_kwargs):
    pass
```

The extension emits a marker with the same package and name as the real macro-owned target. The `symbols` argument is what makes the marker visible through Gazelle's rule index:

```starlark
ctx.targets.add(
    kind = "provider_symbol",
    name = "provider",
    attrs = {"importpath": "example.com/provider"},
    symbols = [
        aspect.Symbol(
            id = "example.com/provider",
            provider = "go",
        ),
    ],
)
```

Gazelle then writes the marker next to the real macro call:

```starlark
provider_bundle(name = "provider")

provider_symbol(
    name = "provider",
    importpath = "example.com/provider",
)
```

Bazel gets `//generated:provider` from `provider_bundle`; the no-op marker creates no Bazel target. Gazelle uses the marker's attached `aspect.Symbol` to index the same label. Extensions must maintain one marker per exported import-to-label mapping because `ctx.add_symbol` alone is not visible to other Gazelle languages.

## Change

`GazelleHost.CrossResolve` now returns the union of:

- its existing Orion rule-index matches
- Orion symbol-database entries whose `id` equals `imp.Imp` and whose `provider_type` equals `imp.Lang`

The method converts database entries to absolute labels and removes exact duplicate labels across both sources. Distinct matching labels remain distinct so the consuming language can apply its normal selection or ambiguity handling.

In the example above, `ctx.add_symbol` is sufficient for Go to resolve `example.com/provider` to `//generated:provider`. The synthetic marker can be removed.

## Compatibility

This changes no Orion extension API or configuration schema. `CrossResolve` keeps its existing rule-index lookup, then adds matching symbol-database labels.

Cross-language resolution can now select a registered symbol before the consuming language reaches its unresolved-import fallback. Exact duplicate labels collapse to one result. Multiple distinct matching labels may surface the consuming language's normal ambiguity behavior.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Orion extensions can satisfy imports from other Gazelle languages through `ctx.add_symbol`, including labels that have no importable representation in Gazelle's rule index.

### Test plan

The new integration fixture uses `filegroup` targets as minimal labels that do not advertise the Go import through the rule index. Its Orion extension registers `example.com/provider`:

- once with `provider_type = "proto"` and the wrong label
- twice with `provider_type = "go"` and the correct label

A Go consumer imports `example.com/provider`. The expected BUILD output contains one dependency on `:provider`, which verifies database lookup, provider-type filtering, and duplicate database-registration removal.

- New test case added
- `cd runner && bazel test //tests:crossresolve-go-imports-orion-db_test --nocache_test_results --test_output=errors`
