### PR TITLE
fix: do not output log errors with allowJs when transpiling jsx

### DIFF
--- a/language/js/generate.go
+++ b/language/js/generate.go
@@ -1690,36 +1690,48 @@ func isDataFileExt(e string) bool {
 	return e == ".json"
 }
 
-func toJsExt(e string) string {
+func jsExt(e string) (string, bool) {
 	switch e {
-	case ".ts", ".tsx":
-		return ".js"
+	case ".ts", ".tsx", ".jsx":
+		return ".js", true
 	case ".cts":
-		return ".cjs"
+		return ".cjs", true
 	case ".mts":
-		return ".mjs"
-	case ".jsx":
-		return ".js"
+		return ".mjs", true
 	case ".js", ".cjs", ".mjs", ".json":
-		return e
+		return e, true
 	default:
-		BazelLog.Errorf("Unknown extension %q", e)
-		return ".js"
+		return ".js", false
 	}
 }
 
-func toDtsExt(e string) string {
+func dtsExt(e string) (string, bool) {
 	switch e {
-	case ".ts", ".tsx":
-		return ".d.ts"
+	case ".ts", ".tsx", ".jsx":
+		return ".d.ts", true
 	case ".cts":
-		return ".d.cts"
+		return ".d.cts", true
 	case ".mts":
-		return ".d.mts"
+		return ".d.mts", true
 	default:
-		BazelLog.Errorf("Unknown extension %q", e)
-		return ".d.ts"
+		return ".d.ts", false
 	}
+}
+
+func toJsExt(e string) string {
+	js, known := jsExt(e)
+	if !known {
+		BazelLog.Errorf("Unknown extension %q, assuming it compiles to %q", e, js)
+	}
+	return js
+}
+
+func toDtsExt(e string) string {
+	dts, known := dtsExt(e)
+	if !known {
+		BazelLog.Errorf("Unknown extension %q, assuming it declares %q", e, dts)
+	}
+	return dts
 }
 
 // Normalize the given import statement from a relative path

--- a/language/js/generate_test.go
+++ b/language/js/generate_test.go
@@ -237,6 +237,11 @@ func TestGenerate(t *testing.T) {
 		assertImports(t, "bar/index.d.ts", []string{"bar/index", "bar/index.d.ts", "bar/index.js", "bar"})
 		assertImports(t, "bar/index.tsx", []string{"bar/index", "bar/index.d.ts", "bar/index.js", "bar"})
 
+		// .jsx is transpiled to .js + .d.ts like .tsx
+		assertImports(t, "bar.jsx", []string{"bar", "bar.d.ts", "bar.js"})
+		assertImports(t, "foo/bar.jsx", []string{"foo/bar", "foo/bar.d.ts", "foo/bar.js"})
+		assertImports(t, "bar/index.jsx", []string{"bar/index", "bar/index.d.ts", "bar/index.js", "bar"})
+
 		// .mjs and .cjs files require an extension
 		assertImports(t, "bar.mts", []string{"bar.mjs", "bar.d.mts"})
 		assertImports(t, "bar/index.mts", []string{"bar/index.mjs", "bar/index.d.mts", "bar"})
@@ -484,6 +489,26 @@ func TestSrcsArePinned(t *testing.T) {
 			}
 			if got := srcsArePinned(f.Rules[0]); got != tc.want {
 				t.Errorf("srcsArePinned = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Every extension the generator transpiles must have an explicit js+dts mapping,
+// otherwise it falls through to the "Unknown extension" branch.
+func TestTranspiledExtsAreMapped(t *testing.T) {
+	for _, ext := range []string{".ts", ".tsx", ".jsx", ".cts", ".mts", ".js", ".cjs", ".mjs", ".json", ".png"} {
+		t.Run(ext, func(t *testing.T) {
+			transpiled := isTranspiledSourceFileExt(ext)
+
+			if _, known := dtsExt(ext); known != transpiled {
+				t.Errorf("dtsExt(%q) known = %v, want %v (isTranspiledSourceFileExt)", ext, known, transpiled)
+			}
+
+			// Non-transpiled source and data files still have a known js extension.
+			wantJs := transpiled || isSourceFileExt(ext) || isDataFileExt(ext)
+			if _, known := jsExt(ext); known != wantJs {
+				t.Errorf("jsExt(%q) known = %v, want %v", ext, known, wantJs)
 			}
 		})
 	}

--- a/language/js/tests/jsx_transpiled/BUILD.in
+++ b/language/js/tests/jsx_transpiled/BUILD.in
@@ -1,0 +1,1 @@
+# gazelle:js_files **/*.{ts,tsx,jsx}

--- a/language/js/tests/jsx_transpiled/BUILD.out
+++ b/language/js/tests/jsx_transpiled/BUILD.out
@@ -1,0 +1,9 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+# gazelle:js_files **/*.{ts,tsx,jsx}
+
+ts_project(
+    name = "jsx_transpiled",
+    srcs = ["main.ts"],
+    deps = ["//lib"],
+)

--- a/language/js/tests/jsx_transpiled/WORKSPACE
+++ b/language/js/tests/jsx_transpiled/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "jsx_transpiled")

--- a/language/js/tests/jsx_transpiled/lib/BUILD.out
+++ b/language/js/tests/jsx_transpiled/lib/BUILD.out
@@ -1,0 +1,9 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+ts_project(
+    name = "lib",
+    srcs = [
+        "component.jsx",
+        "index.jsx",
+    ],
+)

--- a/language/js/tests/jsx_transpiled/lib/component.jsx
+++ b/language/js/tests/jsx_transpiled/lib/component.jsx
@@ -1,0 +1,1 @@
+export const Component = () => <div>hello</div>;

--- a/language/js/tests/jsx_transpiled/lib/index.jsx
+++ b/language/js/tests/jsx_transpiled/lib/index.jsx
@@ -1,0 +1,1 @@
+export { Component } from './component';

--- a/language/js/tests/jsx_transpiled/main.ts
+++ b/language/js/tests/jsx_transpiled/main.ts
@@ -1,0 +1,11 @@
+// The .jsx index file imported as a directory
+import { Component } from './lib';
+
+// The .jsx source imported as its transpiled .js output
+import { Component as Direct } from './lib/component.js';
+
+// The .jsx source imported as its generated .d.ts output
+import type { Component as Typed } from './lib/component.d.ts';
+
+export { Component, Direct };
+export type { Typed };


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
