### PR TITLE
fix: register configured map_kind mappings before resolution

### DIFF
--- a/runner/MODULE.bazel
+++ b/runner/MODULE.bazel
@@ -43,8 +43,8 @@ single_version_override(
     patch_strip = 1,
     patches = [
         "//patches:bazelbuild_bazel-gazelle_aspect-cli.patch",
-        "//patches:bazelbuild_bazel-gazelle_aspect-watchman.patch",
         "//pkg/git:gazelle-gitignore.patch",
+        "//patches:bazelbuild_bazel-gazelle_aspect-watchman.patch",
     ],
 )
 

--- a/runner/MODULE.bazel
+++ b/runner/MODULE.bazel
@@ -43,8 +43,8 @@ single_version_override(
     patch_strip = 1,
     patches = [
         "//patches:bazelbuild_bazel-gazelle_aspect-cli.patch",
-        "//pkg/git:gazelle-gitignore.patch",
         "//patches:bazelbuild_bazel-gazelle_aspect-watchman.patch",
+        "//pkg/git:gazelle-gitignore.patch",
     ],
 )
 

--- a/runner/MODULE.bazel
+++ b/runner/MODULE.bazel
@@ -69,8 +69,8 @@ go_deps2.module_override(
     patch_strip = 1,
     patches = [
         "//patches:bazelbuild_bazel-gazelle_aspect-cli.patch",
-        "//patches:bazelbuild_bazel-gazelle_aspect-watchman.patch",
         "//pkg/git:gazelle-gitignore.patch",
+        "//patches:bazelbuild_bazel-gazelle_aspect-watchman.patch",
     ],
     path = "github.com/bazelbuild/bazel-gazelle",
 )

--- a/runner/MODULE.bazel
+++ b/runner/MODULE.bazel
@@ -69,8 +69,8 @@ go_deps2.module_override(
     patch_strip = 1,
     patches = [
         "//patches:bazelbuild_bazel-gazelle_aspect-cli.patch",
-        "//pkg/git:gazelle-gitignore.patch",
         "//patches:bazelbuild_bazel-gazelle_aspect-watchman.patch",
+        "//pkg/git:gazelle-gitignore.patch",
     ],
     path = "github.com/bazelbuild/bazel-gazelle",
 )

--- a/runner/tests/map-kind-deps/BUILD.in
+++ b/runner/tests/map-kind-deps/BUILD.in
@@ -1,0 +1,10 @@
+# Exclude wrapped.ts from source target generation.
+# gazelle:js_files *.js
+# gazelle:map_kind ts_project my_ts_project //tools:kinds.bzl
+load("//tools:kinds.bzl", "my_ts_project")
+
+my_ts_project(
+    name = "provider",
+    out_dir = "gen",
+    srcs = ["wrapped.ts"],
+)

--- a/runner/tests/map-kind-deps/BUILD.out
+++ b/runner/tests/map-kind-deps/BUILD.out
@@ -1,0 +1,10 @@
+# Exclude wrapped.ts from source target generation.
+# gazelle:js_files *.js
+# gazelle:map_kind ts_project my_ts_project //tools:kinds.bzl
+load("//tools:kinds.bzl", "my_ts_project")
+
+my_ts_project(
+    name = "provider",
+    srcs = ["wrapped.ts"],
+    out_dir = "gen",
+)

--- a/runner/tests/map-kind-deps/WORKSPACE
+++ b/runner/tests/map-kind-deps/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "map_kind_deps")

--- a/runner/tests/map-kind-deps/app/BUILD.in
+++ b/runner/tests/map-kind-deps/app/BUILD.in
@@ -1,0 +1,2 @@
+# Generate a ts_project for main.ts.
+# gazelle:js_files **/*.{js,ts}

--- a/runner/tests/map-kind-deps/app/BUILD.out
+++ b/runner/tests/map-kind-deps/app/BUILD.out
@@ -1,0 +1,10 @@
+load("//tools:kinds.bzl", "my_ts_project")
+
+# Generate a ts_project for main.ts.
+# gazelle:js_files **/*.{js,ts}
+
+my_ts_project(
+    name = "app",
+    srcs = ["main.ts"],
+    deps = ["//:provider"],
+)

--- a/runner/tests/map-kind-deps/app/main.ts
+++ b/runner/tests/map-kind-deps/app/main.ts
@@ -1,0 +1,3 @@
+import { wrapped } from "../gen/wrapped";
+
+console.log(wrapped);

--- a/runner/tests/map-kind-deps/wrapped.ts
+++ b/runner/tests/map-kind-deps/wrapped.ts
@@ -1,0 +1,1 @@
+export const wrapped = "wrapped";

--- a/runner/vendored/gazelle/fix-update.go
+++ b/runner/vendored/gazelle/fix-update.go
@@ -358,13 +358,16 @@ func runFixUpdate(wd string, languages []language.Language, cmd command, args []
 		regularFiles := args.RegularFiles
 		genFiles := args.GenFiles
 
+		// Register aliases with every configured mapping: an alias may wrap a
+		// mapped kind even when this package generated no rule of that kind.
 		mrslv.AliasedKinds(rel, c.AliasMap)
+		for _, repl := range c.KindMap {
+			mrslv.MappedKind(rel, repl)
+		}
+
 		// If this file is ignored or if Gazelle was not asked to update this
 		// directory, just index the build file and move on.
 		if !update {
-			for _, repl := range c.KindMap {
-				mrslv.MappedKind(rel, repl)
-			}
 			if c.IndexLibraries && f != nil {
 				for _, r := range f.Rules {
 					ruleIndex.AddRule(c, r, f)


### PR DESCRIPTION
Port bazel-contrib/bazel-gazelle#2391 (in v0.53.0) to the vendored runner fix-update.go: register every configured KindMap mapping with the meta resolver per package, not only mappings applied to generated rules. A package containing only a pre-existing rule of a mapped kind otherwise loses dependency resolution for rules resolved against it.

Add a runner fixture test mirroring the js test from 63f4d92580 (gazelle_map_kind_deps).

Also reorder the dev go_deps module_override patch list so the gitignore patch precedes the watchman patch, matching single_version_override; the watchman hunk anchors on a gitignore patch marker line.

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
